### PR TITLE
[WIP] Implemented PMM-26 and started fixing tests

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -182,7 +182,7 @@ func (agent *Agent) Run() error {
 				output, err := self.Run()
 				agent.reply(cmd.Reply(output, err))
 				logger.Debug("Restart:done")
-				return ErrRestart
+				return nil
 			case "Stop":
 				logger.Debug("cmd:stop")
 				logger.Info("Stopping", cmd)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -48,11 +48,11 @@ type AgentTestSuite struct {
 	configFile string
 	// Log
 	logger  *pct.Logger
-	logChan chan *proto.LogEntry
+	logChan chan proto.LogEntry
 	// Agent
 	agent        *agent.Agent
 	config       *pc.Agent
-	services     map[string]*mock.MockServiceManager
+	services     map[string]pct.ServiceManager
 	servicesMap  map[string]pct.ServiceManager
 	client       *mock.WebsocketClient
 	sendDataChan chan interface{}
@@ -83,13 +83,13 @@ func (s *AgentTestSuite) SetUpSuite(t *C) {
 
 	// Log
 	// todo: use log.Manager instead
-	s.logChan = make(chan *proto.LogEntry, 10)
+	s.logChan = make(chan proto.LogEntry, 10)
 	s.logger = pct.NewLogger(s.logChan, "agent-test")
 
 	// Agent
 	s.config = &pc.Agent{
 		UUID:        "abc-123-def",
-		ApiHostname: "localhost",
+		ApiHostname: "http://localhost",
 		Keepalive:   1, // don't send while testing
 	}
 
@@ -108,7 +108,7 @@ func (s *AgentTestSuite) SetUpSuite(t *C) {
 func (s *AgentTestSuite) SetUpTest(t *C) {
 	// Before each test, create an agent.  Tests make change the agent,
 	// so this ensures each test starts with an agent with known values.
-	s.services = make(map[string]*mock.MockServiceManager)
+	s.services = make(map[string]pct.ServiceManager)
 	s.services["qan"] = mock.NewMockServiceManager("qan", s.readyChan, s.traceChan)
 	s.services["mm"] = mock.NewMockServiceManager("mm", s.readyChan, s.traceChan)
 
@@ -122,10 +122,11 @@ func (s *AgentTestSuite) SetUpTest(t *C) {
 		"mm":  s.services["mm"],
 		"qan": s.services["qan"],
 	}
-	s.agent = agent.NewAgent(s.config, s.logger, s.api, s.client, s.servicesMap)
 
 	// Run the agent.
+	s.agent = agent.NewAgent(s.config, s.logger, s.client, "http://localhost", s.servicesMap)
 	s.agentRunning = true
+
 	go func() {
 		s.agent.Run()
 		s.doneChan <- true
@@ -280,8 +281,8 @@ func (s *AgentTestSuite) TestStartStopService(t *C) {
 	qanConfig := &pc.QAN{
 		Interval:          60,         // seconds
 		MaxSlowLogSize:    1073741824, // 1 GiB
-		RemoveOldSlowLogs: "true",
-		ExampleQueries:    "true",
+		RemoveOldSlowLogs: true,
+		ExampleQueries:    true,
 		WorkerRunTime:     120, // seconds
 	}
 
@@ -386,8 +387,8 @@ func (s *AgentTestSuite) TestStartServiceSlow(t *C) {
 	qanConfig := &pc.QAN{
 		Interval:          60,         // seconds
 		MaxSlowLogSize:    1073741824, // 1 GiB
-		RemoveOldSlowLogs: "true",
-		ExampleQueries:    "true",
+		RemoveOldSlowLogs: true,
+		ExampleQueries:    true,
 		WorkerRunTime:     120, // seconds
 	}
 	qanConfigData, _ := json.Marshal(qanConfig)
@@ -478,7 +479,11 @@ func (s *AgentTestSuite) TestLoadConfig(t *C) {
 	// Load a partial config to make sure LoadConfig() works in general but also
 	// when the config has missing options (which is normal).
 	os.Remove(s.configFile)
-	test.CopyFile(sample+"/config001.json", s.configFile)
+	err := test.CopyFile(sample+"/config001.json", s.configFile)
+	if err != nil {
+		t.Fatalf("cannot copy config file: %s", err.Error())
+	}
+
 	bytes, err := agent.LoadConfig()
 	t.Assert(err, IsNil)
 	got := &pc.Agent{}
@@ -540,7 +545,7 @@ func (s *AgentTestSuite) TestGetConfig(t *C) {
 	expect := []proto.AgentConfig{
 		{
 			Service: "agent",
-			Config:  string(bytes),
+			Running: string(bytes),
 		},
 	}
 
@@ -575,19 +580,20 @@ func (s *AgentTestSuite) TestGetAllConfigs(t *C) {
 	expectConfigs := []proto.AgentConfig{
 		{
 			Service: "agent",
-			Config:  string(bytes),
+			Running: string(bytes),
 		},
 		{
 			Service: "mm",
-			Config:  `{"Foo":"bar"}`,
+			Set:     `{"Foo":"bar"}`,
 		},
 		{
 			Service: "qan",
-			Config:  `{"Foo":"bar"}`,
+			Set:     `{"Foo":"bar"}`,
 		},
 	}
 	if ok, diff := IsDeeply(gotConfigs, expectConfigs); !ok {
 		Dump(gotConfigs)
+		Dump(expectConfigs)
 		t.Error(diff)
 	}
 }
@@ -738,7 +744,7 @@ func (s *AgentTestSuite) TestRestart(t *C) {
 		os.Remove(pct.Basedir.File("start-script"))
 	}()
 
-	newAgent := agent.NewAgent(s.config, s.logger, s.api, s.client, s.servicesMap)
+	newAgent := agent.NewAgent(s.config, s.logger, s.client, "localhost", s.servicesMap)
 	doneChan := make(chan error, 1)
 	go func() {
 		doneChan <- newAgent.Run()
@@ -786,6 +792,6 @@ func (s *AgentTestSuite) TestCmdToService(t *C) {
 	t.Check(reply[0].Error, Equals, "")
 	t.Check(reply[0].Cmd, Equals, "Hello")
 
-	t.Assert(s.services["mm"].Cmds, HasLen, 1)
-	t.Check(s.services["mm"].Cmds[0].Cmd, Equals, "Hello")
+	t.Assert(s.services["mm"].(*mock.MockServiceManager).Cmds, HasLen, 1)
+	t.Check(s.services["mm"].(*mock.MockServiceManager).Cmds[0].Cmd, Equals, "Hello")
 }

--- a/bin/percona-qan-agent-installer/main.go
+++ b/bin/percona-qan-agent-installer/main.go
@@ -119,7 +119,8 @@ func main() {
 	}
 
 	agentConfig := &pc.Agent{
-		ApiHostname: qanAPIURL.String(),
+		ApiHostname: qanAPIURL.Host,
+		ApiPath:     qanAPIURL.Path,
 	}
 
 	if flagMySQLSocket != "" && flagMySQLHost != "" {

--- a/bin/percona-qan-agent-installer/main.go
+++ b/bin/percona-qan-agent-installer/main.go
@@ -21,8 +21,10 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/percona/pmm/proto"
 	pc "github.com/percona/pmm/proto/config"
@@ -80,7 +82,7 @@ func init() {
 
 }
 
-var portSuffix *regexp.Regexp = regexp.MustCompile(`:\d+$`)
+var portSuffix = regexp.MustCompile(`:\d+$`)
 
 func main() {
 	// It flag is unknown it exist with os.Exit(10),
@@ -91,9 +93,8 @@ func main() {
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		if err == flag.ErrHelp {
 			return
-		} else {
-			log.Fatal(err)
 		}
+		log.Fatal(err)
 	}
 
 	args := fs.Args()
@@ -104,12 +105,21 @@ func main() {
 		os.Exit(1)
 	}
 
-	if !portSuffix.Match([]byte(args[0])) {
-		args[0] += ":" + DEFAULT_DATASTORE_PORT
+	qanAPIURL, err := url.Parse(args[0])
+	if err != nil {
+		log.Fatal("expected arg in the form [schema://]host[:port][path]")
+	}
+
+	if !portSuffix.MatchString(qanAPIURL.Host) {
+		qanAPIURL.Host += ":" + DEFAULT_DATASTORE_PORT
+	}
+
+	if !strings.HasPrefix(qanAPIURL.Scheme, "http") {
+		qanAPIURL.Scheme = "http://" + qanAPIURL.Scheme
 	}
 
 	agentConfig := &pc.Agent{
-		ApiHostname: args[0],
+		ApiHostname: qanAPIURL.String(),
 	}
 
 	if flagMySQLSocket != "" && flagMySQLHost != "" {

--- a/bin/percona-qan-agent/main.go
+++ b/bin/percona-qan-agent/main.go
@@ -184,7 +184,7 @@ func run(agentConfig *pc.Agent) error {
 	go func() {
 		haveWarned := false
 		for {
-			if err := api.Connect(agentConfig.ApiHostname, agentConfig.UUID); err != nil {
+			if err := api.Connect(agentConfig.ApiHostname, agentConfig.ApiPath, agentConfig.UUID); err != nil {
 				if !haveWarned {
 					golog.Printf("Cannot connect to API: %s. Verify that the"+
 						" agent UUID and API hostname printed above are"+

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -35,7 +35,7 @@ import (
 func Test(t *testing.T) { TestingT(t) }
 
 type TestSuite struct {
-	logChan   chan *proto.LogEntry
+	logChan   chan proto.LogEntry
 	logger    *pct.Logger
 	server    *mock.WebsocketServer
 	api       *mock.API
@@ -55,7 +55,7 @@ const (
 )
 
 func (s *TestSuite) SetUpSuite(t *C) {
-	s.logChan = make(chan *proto.LogEntry, 10)
+	s.logChan = make(chan proto.LogEntry, 10)
 	s.logger = pct.NewLogger(s.logChan, "ws")
 
 	mock.SendChan = make(chan interface{}, 5)

--- a/pct/api.go
+++ b/pct/api.go
@@ -40,7 +40,7 @@ var requiredEntryLinks = []string{"agents", "instances"}
 var requiredAgentLinks = []string{"cmd", "log", "data", "self"}
 
 type APIConnector interface {
-	Connect(hostname, basePth, agentUuid string) error
+	Connect(hostname, basePath, agentUuid string) error
 	Init(hostname string, headers map[string]string) (code int, err error)
 	Get(url string) (int, []byte, error)
 	Post(url string, data []byte) (*http.Response, []byte, error)

--- a/pct/api.go
+++ b/pct/api.go
@@ -40,7 +40,7 @@ var requiredEntryLinks = []string{"agents", "instances"}
 var requiredAgentLinks = []string{"cmd", "log", "data", "self"}
 
 type APIConnector interface {
-	Connect(hostname, agentUuid string) error
+	Connect(hostname, basePth, agentUuid string) error
 	Init(hostname string, headers map[string]string) (code int, err error)
 	Get(url string) (int, []byte, error)
 	Post(url string, data []byte) (*http.Response, []byte, error)
@@ -154,11 +154,11 @@ func URL(hostname string, paths ...string) string {
 	return url
 }
 
-func (a *API) Connect(hostname, agentUuid string) error {
+func (a *API) Connect(hostname, basePath, agentUuid string) error {
 	schema := "http://" // todo: support internal/private HTTPS
 
 	// Get entry links: GET <API hostname>/
-	entryLinks, err := a.getLinks(schema + hostname)
+	entryLinks, err := a.getLinks(schema + hostname + basePath)
 	if err != nil {
 		return err
 	}

--- a/test/agent/config001.json
+++ b/test/agent/config001.json
@@ -1,5 +1,6 @@
 {
 	"ApiHostname": "localhost",
 	"ApiKey": "123",
-	"UUID": "abc-123-def"
+	"UUID": "abc-123-def",
+    "PidFile": "percona-agent.pid"
 }

--- a/test/app.go
+++ b/test/app.go
@@ -48,7 +48,7 @@ func init() {
 	for i := 0; i < 3; i++ {
 		dir = dir + "/../"
 		if FileExists(dir + ".git") {
-			RootDir = filepath.Clean(dir + "agent/test")
+			RootDir = filepath.Clean(dir + "test")
 			break
 		}
 	}
@@ -96,7 +96,7 @@ func WriteData(data interface{}, filename string) {
 	ioutil.WriteFile(filename, bytes, os.ModePerm)
 }
 
-func DrainLogChan(c chan *proto.LogEntry) {
+func DrainLogChan(c chan proto.LogEntry) {
 	for {
 		select {
 		case <-c:

--- a/test/mock/api.go
+++ b/test/mock/api.go
@@ -19,6 +19,10 @@ package mock
 
 import (
 	"net/http"
+
+	"github.com/percona/pmm/proto"
+
+	"golang.org/x/net/websocket"
 )
 
 type APIResponse struct {
@@ -54,34 +58,52 @@ func PingAPI(hostname string) (bool, *http.Response) {
 	return true, nil
 }
 
-func (a *API) Init(hostname string, headers map[string]string) (code int, err error) {
-	return http.StatusOK, nil
-}
-
-func (a *API) Connect(hostname, agentUuid string) error {
-	a.hostname = hostname
-	a.agentUuid = agentUuid
-	return nil
-}
+/*
+   Implements all pct/api methods
+*/
 
 func (a *API) AgentLink(resource string) string {
 	return a.links[resource]
+}
+
+func (a *API) AgentUuid() string {
+	return a.agentUuid
+}
+
+func (a *API) Conn() *websocket.Conn {
+	return &websocket.Conn{}
+}
+
+func (a *API) Connect() {
+	return
+}
+
+func (a *API) ConnectOnce(timeout uint) error {
+	return nil
+}
+
+func (a *API) ConnectChan() chan bool {
+	return make(chan bool)
+}
+
+func (a *API) CreateInstance(url string, it interface{}) (bool, error) {
+	return true, nil
+}
+
+func (a *API) Disconnect() error {
+	return nil
+}
+
+func (a *API) DisconnectOnce() error {
+	return nil
 }
 
 func (a *API) EntryLink(resource string) string {
 	return a.links[resource]
 }
 
-func (a *API) Origin() string {
-	return a.origin
-}
-
-func (a *API) Hostname() string {
-	return a.hostname
-}
-
-func (a *API) AgentUuid() string {
-	return a.agentUuid
+func (a *API) ErrorChan() chan error {
+	return make(chan error)
 }
 
 func (a *API) Get(url string) (int, []byte, error) {
@@ -110,6 +132,18 @@ func (a *API) Get(url string) (int, []byte, error) {
 	return code, data, err
 }
 
+func (a *API) Hostname() string {
+	return a.hostname
+}
+
+func (a *API) Init(hostname string, headers map[string]string) (code int, err error) {
+	return http.StatusOK, nil
+}
+
+func (a *API) Origin() string {
+	return a.origin
+}
+
 func (a *API) Post(url string, data []byte) (*http.Response, []byte, error) {
 	return nil, nil, nil
 }
@@ -124,8 +158,36 @@ func (a *API) Put(url string, data []byte) (*http.Response, []byte, error) {
 	return nil, nil, nil
 }
 
-func (a *API) CreateInstance(url string, it interface{}) (bool, error) {
-	return true, nil
+func (a *API) Recv(data interface{}, timeout uint) error {
+	return nil
+}
+
+func (a *API) RecvChan() chan *proto.Cmd {
+	return make(chan *proto.Cmd)
+}
+
+func (a *API) SendBytes(data []byte, timeout uint) error {
+	return nil
+}
+
+func (a *API) SendChan() chan *proto.Reply {
+	return make(chan *proto.Reply)
+}
+
+func (a *API) Start() {
+	return
+}
+
+func (a *API) Status() map[string]string {
+	return make(map[string]string)
+}
+
+func (a *API) Send(data interface{}, timeout uint) error {
+	return nil
+}
+
+func (a *API) Stop() {
+	return
 }
 
 func (a *API) URL(paths ...string) string {

--- a/test/mock/service.go
+++ b/test/mock/service.go
@@ -20,8 +20,8 @@ package mock
 import (
 	"fmt"
 
-	"github.com/percona/qan-agent/pct"
 	"github.com/percona/pmm/proto"
+	"github.com/percona/qan-agent/pct"
 )
 
 type MockServiceManager struct {
@@ -93,4 +93,9 @@ func (m *MockServiceManager) Handle(cmd *proto.Cmd) *proto.Reply {
 
 func (m *MockServiceManager) Reset() {
 	m.status.Update(m.name, "")
+}
+
+func (m *MockServiceManager) GetDefaults() map[string]interface{} {
+
+	return make(map[string]interface{})
 }


### PR DESCRIPTION
agent/agent.go:
- Fixed: Restart should return nil if there is no error
  agent/agent_test.go:
- Fixed all tests
  installer/main.go:
- Changed: API URL can have a path ([scheme://]host[:port][/path])
  client/client_test.go:
- Fixed some variable types.
  test/agent/config001.json:
  -Added PidFile field
  test/app.go:
- Fixed: Rootfile directory was incorrect
- Fixed: argument type for DrainLogChan
  test/mock/api.go:
- Fixed: Added all missing methods to implement pct/api to be able to use the interface instead of type casting.
  test/mock/service.go:
- Added missing method to implement ServiceManager to be able to use the interface instead of type casting

Also found that running agent tests with -cover option produces a race condition.
I've recalled this article: http://herman.asia/running-the-go-race-detector-with-cover

To avoid the race condition test must be executed using:
  go test --cover -covermode=atomic
