### PR TITLE
PMM-226 Agent now uses uri/PATH to get links from api

### DIFF
--- a/bin/percona-qan-agent-installer/main.go
+++ b/bin/percona-qan-agent-installer/main.go
@@ -100,17 +100,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	if !strings.HasPrefix(args[0], "http://") && !strings.HasPrefix(args[0], "https://") {
-		args[0] = "http://" + args[0]
-	}
-
-	qanAPIURL, err := url.Parse(args[0])
+	qanAPIURL, err := parseURLParam(args[0])
 	if err != nil {
 		log.Fatal("expected arg in the form [schema://]host[:port][path]")
-	}
-
-	if !strings.HasPrefix(qanAPIURL.Scheme, "http") {
-		qanAPIURL.Scheme = "http://" + qanAPIURL.Scheme
 	}
 
 	agentConfig := &pc.Agent{
@@ -189,4 +181,16 @@ func main() {
 	}
 
 	os.Exit(0)
+}
+
+func parseURLParam(args0 string) (*url.URL, error) {
+	if !strings.HasPrefix(args0, "http://") && !strings.HasPrefix(args0, "https://") {
+		args0 = "http://" + args0
+	}
+
+	qanAPIURL, err := url.Parse(args0)
+	if err != nil {
+		return nil, fmt.Errorf("expected arg in the form [schema://]host[:port][path]")
+	}
+	return qanAPIURL, nil
 }

--- a/bin/percona-qan-agent-installer/main.go
+++ b/bin/percona-qan-agent-installer/main.go
@@ -158,11 +158,12 @@ func main() {
 	fmt.Println("CTRL-C at any time to quit")
 
 	api := pct.NewAPI()
-	if _, err := api.Init(agentConfig.ApiHostname, nil); err != nil {
-		fmt.Printf("Cannot connect to API %s: %s\n", agentConfig.ApiHostname, err)
+	requestURL := agentConfig.ApiHostname + agentConfig.ApiPath
+	fmt.Printf("API host: %s\n", pct.URL(requestURL))
+	if _, err := api.Init(requestURL, nil); err != nil {
+		fmt.Printf("Cannot connect to API %s: %s\n", requestURL, err)
 		os.Exit(1)
 	}
-	fmt.Printf("API host: %s\n", pct.URL(agentConfig.ApiHostname))
 
 	// Agent stores all its files in the basedir.  This must be called first
 	// because installer uses pct.Basedir and assumes it's already initialized.

--- a/bin/percona-qan-agent-installer/main.go
+++ b/bin/percona-qan-agent-installer/main.go
@@ -23,18 +23,15 @@ import (
 	"log"
 	"net/url"
 	"os"
-	"regexp"
 	"strings"
 
+	"github.com/percona/percona-agent/bin/percona-agent-installer/installer"
+	"github.com/percona/percona-agent/bin/percona-agent-installer/term"
 	"github.com/percona/pmm/proto"
 	pc "github.com/percona/pmm/proto/config"
-	"github.com/percona/qan-agent/bin/percona-qan-agent-installer/installer"
-	"github.com/percona/qan-agent/bin/percona-qan-agent-installer/term"
 	"github.com/percona/qan-agent/instance"
 	"github.com/percona/qan-agent/pct"
 )
-
-const DEFAULT_DATASTORE_PORT = "9001"
 
 var (
 	flagBasedir                 string
@@ -82,8 +79,6 @@ func init() {
 
 }
 
-var portSuffix = regexp.MustCompile(`:\d+$`)
-
 func main() {
 	// It flag is unknown it exist with os.Exit(10),
 	// so exit code=10 is strictly reserved for flags
@@ -105,13 +100,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if !strings.HasPrefix(args[0], "http://") && !strings.HasPrefix(args[0], "https://") {
+		args[0] = "http://" + args[0]
+	}
+
 	qanAPIURL, err := url.Parse(args[0])
 	if err != nil {
 		log.Fatal("expected arg in the form [schema://]host[:port][path]")
-	}
-
-	if !portSuffix.MatchString(qanAPIURL.Host) {
-		qanAPIURL.Host += ":" + DEFAULT_DATASTORE_PORT
 	}
 
 	if !strings.HasPrefix(qanAPIURL.Scheme, "http") {

--- a/bin/percona-qan-agent-installer/main.go
+++ b/bin/percona-qan-agent-installer/main.go
@@ -25,10 +25,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/percona/percona-agent/bin/percona-agent-installer/installer"
-	"github.com/percona/percona-agent/bin/percona-agent-installer/term"
 	"github.com/percona/pmm/proto"
 	pc "github.com/percona/pmm/proto/config"
+	"github.com/percona/qan-agent/bin/percona-qan-agent-installer/installer"
+	"github.com/percona/qan-agent/bin/percona-qan-agent-installer/term"
 	"github.com/percona/qan-agent/instance"
 	"github.com/percona/qan-agent/pct"
 )

--- a/bin/percona-qan-agent/main.go
+++ b/bin/percona-qan-agent/main.go
@@ -105,7 +105,7 @@ func main() {
 
 	bytes, err := agent.LoadConfig()
 	if err != nil {
-		fmt.Print("Error reading agent config file %s: %s", agentConfigFile, err)
+		fmt.Printf("Error reading agent config file %s: %s", agentConfigFile, err)
 		os.Exit(1)
 	}
 	agentConfig := &pc.Agent{}
@@ -114,17 +114,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	apiURL := agentConfig.ApiHostname + agentConfig.ApiPath
 	fmt.Printf("# Version: %s\n", agentVersion)
 	fmt.Printf("# Basedir: %s\n", pct.Basedir.Path())
 	fmt.Printf("# Listen:  %s\n", flagListen)
 	fmt.Printf("# PID:     %d\n", os.Getpid())
-	fmt.Printf("# API:     %s\n", agentConfig.ApiHostname)
+	fmt.Printf("# API:     %s\n", apiURL)
 	fmt.Printf("# UUID:    %s\n", agentConfig.UUID)
 
 	// -ping and exit.
 	if flagPing {
 		t0 := time.Now()
-		code, err := pct.Ping(agentConfig.ApiHostname, nil)
+		code, err := pct.Ping(apiURL, nil)
 		d := time.Now().Sub(t0)
 		if err != nil || code != 200 {
 			fmt.Printf("Ping FAIL (%d %d %s)", d, code, err)

--- a/bin/percona-qan-agent/main.go
+++ b/bin/percona-qan-agent/main.go
@@ -184,7 +184,7 @@ func run(agentConfig *pc.Agent) error {
 	go func() {
 		haveWarned := false
 		for {
-			if err := api.Connect(agentConfig.ApiHostname, agentConfig.UUID); err != nil {
+			if err := api.Connect(agentConfig.ApiHostname, agentConfig.ApiPath, agentConfig.UUID); err != nil {
 				if !haveWarned {
 					golog.Printf("Cannot connect to API: %s. Verify that the"+
 						" agent UUID and API hostname printed above are"+

--- a/pct/api.go
+++ b/pct/api.go
@@ -188,13 +188,17 @@ func (a *API) Connect(hostname, basePath, agentUuid string) error {
 
 func (a *API) Init(hostname string, headers map[string]string) (int, error) {
 	code, err := Ping(hostname, headers)
-	if code == 200 && err == nil {
-		a.mux.Lock()
-		defer a.mux.Unlock()
-		a.hostname = hostname
+	if err != nil {
+		return 0, err
 	}
 
-	return code, err
+	if code != http.StatusOK {
+		return code, fmt.Errorf("Got %d from the API", code)
+	}
+	a.mux.Lock()
+	defer a.mux.Unlock()
+	a.hostname = hostname
+	return code, nil
 }
 
 func (a *API) checkLinks(links map[string]string, req ...string) error {

--- a/pct/api.go
+++ b/pct/api.go
@@ -40,7 +40,7 @@ var requiredEntryLinks = []string{"agents", "instances"}
 var requiredAgentLinks = []string{"cmd", "log", "data", "self"}
 
 type APIConnector interface {
-	Connect(hostname, agentUuid string) error
+	Connect(hostname, basePath, agentUuid string) error
 	Init(hostname string, headers map[string]string) (code int, err error)
 	Get(url string) (int, []byte, error)
 	Post(url string, data []byte) (*http.Response, []byte, error)
@@ -154,11 +154,11 @@ func URL(hostname string, paths ...string) string {
 	return url
 }
 
-func (a *API) Connect(hostname, agentUuid string) error {
+func (a *API) Connect(hostname, basePath, agentUuid string) error {
 	schema := "http://" // todo: support internal/private HTTPS
 
 	// Get entry links: GET <API hostname>/
-	entryLinks, err := a.getLinks(schema + hostname)
+	entryLinks, err := a.getLinks(schema + hostname + basePath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Now the installer accepts a parameter that includes the path in the uri and the uses that path to get links from the API.
There are also some minor/cosmetic changes to make the code more idiomatic. 
