### PR TITLE
PMM-228 Fixed agent tests

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -182,7 +182,7 @@ func (agent *Agent) Run() error {
 				output, err := self.Run()
 				agent.reply(cmd.Reply(output, err))
 				logger.Debug("Restart:done")
-				return ErrRestart
+				return nil
 			case "Stop":
 				logger.Debug("cmd:stop")
 				logger.Info("Stopping", cmd)

--- a/bin/percona-qan-agent/main.go
+++ b/bin/percona-qan-agent/main.go
@@ -184,7 +184,7 @@ func run(agentConfig *pc.Agent) error {
 	go func() {
 		haveWarned := false
 		for {
-			if err := api.Connect(agentConfig.ApiHostname, agentConfig.UUID); err != nil {
+			if err := api.Connect(agentConfig.ApiHostname, agentConfig.ApiPath, agentConfig.UUID); err != nil {
 				if !haveWarned {
 					golog.Printf("Cannot connect to API: %s. Verify that the"+
 						" agent UUID and API hostname printed above are"+

--- a/pct/api.go
+++ b/pct/api.go
@@ -40,7 +40,7 @@ var requiredEntryLinks = []string{"agents", "instances"}
 var requiredAgentLinks = []string{"cmd", "log", "data", "self"}
 
 type APIConnector interface {
-	Connect(hostname, agentUuid string) error
+	Connect(hostname, basePath, agentUuid string) error
 	Init(hostname string, headers map[string]string) (code int, err error)
 	Get(url string) (int, []byte, error)
 	Post(url string, data []byte) (*http.Response, []byte, error)
@@ -154,11 +154,11 @@ func URL(hostname string, paths ...string) string {
 	return url
 }
 
-func (a *API) Connect(hostname, agentUuid string) error {
+func (a *API) Connect(hostname, basePath, agentUuid string) error {
 	schema := "http://" // todo: support internal/private HTTPS
 
 	// Get entry links: GET <API hostname>/
-	entryLinks, err := a.getLinks(schema + hostname)
+	entryLinks, err := a.getLinks(schema + hostname + basePath)
 	if err != nil {
 		return err
 	}

--- a/test/agent/config001.json
+++ b/test/agent/config001.json
@@ -1,5 +1,6 @@
 {
 	"ApiHostname": "localhost",
 	"ApiKey": "123",
-	"UUID": "abc-123-def"
+	"UUID": "abc-123-def",
+    "PidFile": "percona-agent.pid"
 }

--- a/test/app.go
+++ b/test/app.go
@@ -48,7 +48,7 @@ func init() {
 	for i := 0; i < 3; i++ {
 		dir = dir + "/../"
 		if FileExists(dir + ".git") {
-			RootDir = filepath.Clean(dir + "agent/test")
+			RootDir = filepath.Clean(dir + "test")
 			break
 		}
 	}
@@ -96,7 +96,7 @@ func WriteData(data interface{}, filename string) {
 	ioutil.WriteFile(filename, bytes, os.ModePerm)
 }
 
-func DrainLogChan(c chan *proto.LogEntry) {
+func DrainLogChan(c chan proto.LogEntry) {
 	for {
 		select {
 		case <-c:

--- a/test/mock/api.go
+++ b/test/mock/api.go
@@ -19,6 +19,10 @@ package mock
 
 import (
 	"net/http"
+
+	"github.com/percona/pmm/proto"
+
+	"golang.org/x/net/websocket"
 )
 
 type APIResponse struct {
@@ -54,34 +58,52 @@ func PingAPI(hostname string) (bool, *http.Response) {
 	return true, nil
 }
 
-func (a *API) Init(hostname string, headers map[string]string) (code int, err error) {
-	return http.StatusOK, nil
-}
-
-func (a *API) Connect(hostname, agentUuid string) error {
-	a.hostname = hostname
-	a.agentUuid = agentUuid
-	return nil
-}
+/*
+   Implements all pct/api methods
+*/
 
 func (a *API) AgentLink(resource string) string {
 	return a.links[resource]
+}
+
+func (a *API) AgentUuid() string {
+	return a.agentUuid
+}
+
+func (a *API) Conn() *websocket.Conn {
+	return &websocket.Conn{}
+}
+
+func (a *API) Connect() {
+	return
+}
+
+func (a *API) ConnectOnce(timeout uint) error {
+	return nil
+}
+
+func (a *API) ConnectChan() chan bool {
+	return make(chan bool)
+}
+
+func (a *API) CreateInstance(url string, it interface{}) (bool, error) {
+	return true, nil
+}
+
+func (a *API) Disconnect() error {
+	return nil
+}
+
+func (a *API) DisconnectOnce() error {
+	return nil
 }
 
 func (a *API) EntryLink(resource string) string {
 	return a.links[resource]
 }
 
-func (a *API) Origin() string {
-	return a.origin
-}
-
-func (a *API) Hostname() string {
-	return a.hostname
-}
-
-func (a *API) AgentUuid() string {
-	return a.agentUuid
+func (a *API) ErrorChan() chan error {
+	return make(chan error)
 }
 
 func (a *API) Get(url string) (int, []byte, error) {
@@ -110,6 +132,18 @@ func (a *API) Get(url string) (int, []byte, error) {
 	return code, data, err
 }
 
+func (a *API) Hostname() string {
+	return a.hostname
+}
+
+func (a *API) Init(hostname string, headers map[string]string) (code int, err error) {
+	return http.StatusOK, nil
+}
+
+func (a *API) Origin() string {
+	return a.origin
+}
+
 func (a *API) Post(url string, data []byte) (*http.Response, []byte, error) {
 	return nil, nil, nil
 }
@@ -124,8 +158,36 @@ func (a *API) Put(url string, data []byte) (*http.Response, []byte, error) {
 	return nil, nil, nil
 }
 
-func (a *API) CreateInstance(url string, it interface{}) (bool, error) {
-	return true, nil
+func (a *API) Recv(data interface{}, timeout uint) error {
+	return nil
+}
+
+func (a *API) RecvChan() chan *proto.Cmd {
+	return make(chan *proto.Cmd)
+}
+
+func (a *API) SendBytes(data []byte, timeout uint) error {
+	return nil
+}
+
+func (a *API) SendChan() chan *proto.Reply {
+	return make(chan *proto.Reply)
+}
+
+func (a *API) Start() {
+	return
+}
+
+func (a *API) Status() map[string]string {
+	return make(map[string]string)
+}
+
+func (a *API) Send(data interface{}, timeout uint) error {
+	return nil
+}
+
+func (a *API) Stop() {
+	return
 }
 
 func (a *API) URL(paths ...string) string {

--- a/test/mock/service.go
+++ b/test/mock/service.go
@@ -20,8 +20,8 @@ package mock
 import (
 	"fmt"
 
-	"github.com/percona/qan-agent/pct"
 	"github.com/percona/pmm/proto"
+	"github.com/percona/qan-agent/pct"
 )
 
 type MockServiceManager struct {
@@ -93,4 +93,9 @@ func (m *MockServiceManager) Handle(cmd *proto.Cmd) *proto.Reply {
 
 func (m *MockServiceManager) Reset() {
 	m.status.Update(m.name, "")
+}
+
+func (m *MockServiceManager) GetDefaults() map[string]interface{} {
+
+	return make(map[string]interface{})
 }


### PR DESCRIPTION
agent/agent.go:
- Fixed: Restart should return nil if there is no error

agent/agent_test.go:
- Fixed all tests installer/main.go:

client/client_test.go:
- Fixed some variable types.

test/agent/config001.json:
- Added PidFile field

test/app.go:
- Fixed: argument type for DrainLogChan test/mock/api.go:
- Fixed: Added all missing methods to implement pct/api to be able to use
  the interface instead of type casting. test/mock/service.go:
- Added missing method to implement ServiceManager to be able to use the
  interface instead of type casting

Also found that running agent tests with -cover option produces a race
condition.

I've recalled this article:
http://herman.asia/running-the-go-race-detector-with-cover

To avoid the race condition test must be executed using:
`go test --cover -covermode=atomic`

`go test`

```
OK: 13 passed
PASS
```
