### PR TITLE
PMM-411 Added RELOAD provileges to the qan-agent user

### DIFF
--- a/bin/percona-qan-agent-installer/installer/mysql.go
+++ b/bin/percona-qan-agent-installer/installer/mysql.go
@@ -43,7 +43,7 @@ func MakeGrant(dsn dsn.DSN, mysqlMaxUserConns int64) []string {
 	// Just in case, disable it for this session
 	grants := []string{
 		"SET SESSION old_passwords=0",
-		fmt.Sprintf("GRANT SUPER, PROCESS, USAGE, SELECT ON *.* TO '%s'@'%s' IDENTIFIED BY '%s' WITH MAX_USER_CONNECTIONS %d",
+		fmt.Sprintf("GRANT SUPER, PROCESS, USAGE, SELECT, RELOAD ON *.* TO '%s'@'%s' IDENTIFIED BY '%s' WITH MAX_USER_CONNECTIONS %d",
 			dsn.Username, host, dsn.Password, mysqlMaxUserConns),
 		fmt.Sprintf("GRANT UPDATE, DELETE, DROP ON performance_schema.* TO '%s'@'%s' IDENTIFIED BY '%s' WITH MAX_USER_CONNECTIONS %d",
 			dsn.Username, host, dsn.Password, mysqlMaxUserConns),

--- a/bin/percona-qan-agent-installer/installer/mysql_test.go
+++ b/bin/percona-qan-agent-installer/installer/mysql_test.go
@@ -44,7 +44,7 @@ func (s *MySQLTestSuite) TestMakeGrant(t *C) {
 	got := i.MakeGrant(dsn, maxOpenConnections)
 	expect := []string{
 		"SET SESSION old_passwords=0",
-		"GRANT SUPER, PROCESS, USAGE, SELECT ON *.* TO 'new-user'@'localhost' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
+		"GRANT SUPER, PROCESS, USAGE, SELECT, RELOAD ON *.* TO 'new-user'@'localhost' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 		"GRANT UPDATE, DELETE, DROP ON performance_schema.* TO 'new-user'@'localhost' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 	}
 	t.Check(got, DeepEquals, expect)
@@ -53,7 +53,7 @@ func (s *MySQLTestSuite) TestMakeGrant(t *C) {
 	got = i.MakeGrant(dsn, maxOpenConnections)
 	expect = []string{
 		"SET SESSION old_passwords=0",
-		"GRANT SUPER, PROCESS, USAGE, SELECT ON *.* TO 'new-user'@'127.0.0.1' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
+		"GRANT SUPER, PROCESS, USAGE, SELECT, RELOAD ON *.* TO 'new-user'@'127.0.0.1' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 		"GRANT UPDATE, DELETE, DROP ON performance_schema.* TO 'new-user'@'127.0.0.1' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 	}
 	t.Check(got, DeepEquals, expect)
@@ -62,7 +62,7 @@ func (s *MySQLTestSuite) TestMakeGrant(t *C) {
 	got = i.MakeGrant(dsn, maxOpenConnections)
 	expect = []string{
 		"SET SESSION old_passwords=0",
-		"GRANT SUPER, PROCESS, USAGE, SELECT ON *.* TO 'new-user'@'%' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
+		"GRANT SUPER, PROCESS, USAGE, SELECT, RELOAD ON *.* TO 'new-user'@'%' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 		"GRANT UPDATE, DELETE, DROP ON performance_schema.* TO 'new-user'@'%' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 	}
 	t.Check(got, DeepEquals, expect)
@@ -72,7 +72,7 @@ func (s *MySQLTestSuite) TestMakeGrant(t *C) {
 	got = i.MakeGrant(dsn, maxOpenConnections)
 	expect = []string{
 		"SET SESSION old_passwords=0",
-		"GRANT SUPER, PROCESS, USAGE, SELECT ON *.* TO 'new-user'@'localhost' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
+		"GRANT SUPER, PROCESS, USAGE, SELECT, RELOAD ON *.* TO 'new-user'@'localhost' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 		"GRANT UPDATE, DELETE, DROP ON performance_schema.* TO 'new-user'@'localhost' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 	}
 	t.Check(got, DeepEquals, expect)


### PR DESCRIPTION
This is needed to be able to FLUSH LOGS for slow log rotation
