### PR TITLE
PMM-419 fixed config conn opening

### DIFF
--- a/qan/config.go
+++ b/qan/config.go
@@ -42,12 +42,15 @@ var (
 )
 
 func ReadMySQLConfig(conn mysql.Connector) error {
-	err := conn.Connect()
-	if err != nil {
-		return err
+	if _, err := conn.Uptime(); err != nil {
+		err := conn.Connect()
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
 	}
 
-	perfschemaStatus, err := conn.GetGlobalVarString("performance_schema")
+	perfschemaStatus, _ := conn.GetGlobalVarString("performance_schema")
 	if pct.ToBool(perfschemaStatus) {
 		DEFAULT_COLLECT_FROM = "perfschema"
 	}


### PR DESCRIPTION
This fixes agent showing:

```
2016/10/06 01:16:00.000582 WARNING qan-interval Cannot connect to MySQL qan-agent:***@unix(/var/run/mysqld/mysqld.sock): Error 1226: User 'qan-agent' has exceeded the 'max_user_connections' resource (current value: 5)
```

@askomorokhov @Nailya @roman-vynar 
