### PR TITLE
`curl https://glide.sh/get | sh` fails on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ addons:
       - mongodb-org
 
 install:
-  - mkdir $GOPATH/bin
-  - curl https://glide.sh/get | sh
+  - go get -u github.com/Masterminds/glide
   - glide install
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ See the [PMM docs](https://www.percona.com/doc/percona-monitoring-and-management
 
 1. Setup [`GOPATH`](https://golang.org/doc/code.html#GOPATH).
 2. Clone repository to `GOPATH`: `go get -v github.com/percona/qan-agent`.
-3. Install released version of Glide: `curl https://glide.sh/get | sh` or `brew install glide`.
+3. Install [`glide`](https://github.com/Masterminds/glide#install):
+   * `curl https://glide.sh/get | sh` or
+   * `brew install glide` or
+   * `go get -u github.com/Masterminds/glide` for development version (`master` branch).
 4. Fetch dependencies: `glide install`.
 5. Install agent and installer: `go install -v github.com/percona/qan-agent/bin/...`. Binaries will be created in `$GOPATH/bin`.


### PR DESCRIPTION
`curl https://glide.sh/get | sh` fails on travis with error `Sorry, we dont have a dist for your system: linux amd64`. This partially reverts https://github.com/percona/qan-agent/pull/42

upstream:
* https://github.com/Masterminds/glide/issues/708
* https://github.com/Masterminds/glide/issues/639
* https://github.com/Masterminds/glide/issues/750
also [glide.sh is 2 minor versions behind](https://github.com/Masterminds/glide/issues/834)