### PR TITLE
PMM-949: fix mapping MySQL bool variables to golang bool

### DIFF
--- a/.travis-install-mysql.sh
+++ b/.travis-install-mysql.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+MYSQL_APT_CONFIG="mysql-apt-config_0.8.6-1_all.deb"
+
+echo "Installing MySQL ${MYSQL_VERSION}..."
+echo mysql-apt-config mysql-apt-config/select-server select mysql-${MYSQL_VERSION} | sudo debconf-set-selections
+wget http://dev.mysql.com/get/${MYSQL_APT_CONFIG}
+sudo dpkg --install ${MYSQL_APT_CONFIG}
+sudo apt-get update -q
+sudo apt-get install -q -y -o Dpkg::Options::=--force-confnew mysql-server
+sudo mysql_upgrade

--- a/.travis-install-mysql.sh
+++ b/.travis-install-mysql.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-
-docker run \
-  --name mysql \
-  -p ${MYSQL_HOST}:${MYSQL_PORT}:3306 \
-  -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
-  -d \
-  mysql:${MYSQL_VERSION}

--- a/.travis-install-mysql.sh
+++ b/.travis-install-mysql.sh
@@ -1,11 +1,9 @@
 #!/bin/sh
 
-MYSQL_APT_CONFIG="mysql-apt-config_0.8.6-1_all.deb"
 
-echo "Installing MySQL ${MYSQL_VERSION}..."
-echo mysql-apt-config mysql-apt-config/select-server select mysql-${MYSQL_VERSION} | sudo debconf-set-selections
-wget http://dev.mysql.com/get/${MYSQL_APT_CONFIG}
-sudo dpkg --install ${MYSQL_APT_CONFIG}
-sudo apt-get update -q
-sudo apt-get install -q -y -o Dpkg::Options::=--force-confnew mysql-server
-sudo mysql_upgrade
+docker run \
+  --name mysql \
+  -p ${MYSQL_HOST}:${MYSQL_PORT}:3306 \
+  -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+  -d \
+  mysql:${MYSQL_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language: go
 
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: required
 
 language: go
@@ -5,7 +6,7 @@ language: go
 go:
   - 1.8.x
 
-services: &services
+services:
   - mysql
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ go:
   - 1.8.x
 
 services:
-  - mongodb
   - mysql
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ env:
 matrix:
   include:
     - go: 1.7.x
+      env:
     - go: tip
+      env:
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,19 @@ sudo: required
 language: go
 
 go:
-  - 1.8
-  - tip
+  - 1.8.x
 
-services:
+services: &services
   - mysql
   - docker
 
 env:
-  global:
+  global: &global
     - MYSQL_USER="root"
     - MYSQL_HOST="127.0.0.1"
     - MYSQL_PORT="3406"
     - PCT_TEST_MYSQL_DSN="${MYSQL_USER}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/?parseTime=true"
-  matrix:
+  matrix: &matrix
     - MYSQL_IMAGE=mysql:5.5
     - MYSQL_IMAGE=mysql:5.6
     - MYSQL_IMAGE=mysql:5.7
@@ -25,6 +24,20 @@ env:
     - MONGODB_IMAGE=mongo:3.2
     - MONGODB_IMAGE=mongo:3.4
     - MONGODB_IMAGE=mongo:3.5
+
+matrix:
+  include:
+    - go: 1.7.x
+      services: *services
+      env:
+        global: *global
+        matrix: *matrix
+  include:
+    - go: tip
+      services: *services
+      env:
+        global: *global
+        matrix: *matrix
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,6 @@ sudo: required
 
 language: go
 
-matrix:
-  include:
-    - go: 1.8.x
-      env:
-        matrix:
-          - MYSQL_IMAGE=mysql:5.6
-          - MYSQL_IMAGE=mysql:5.7
-          - MONGODB_IMAGE=mongo:3.2
-          - MONGODB_IMAGE=mongo:3.4
-    - go: 1.7.x
-
 services:
   - mysql
   - docker
@@ -23,6 +12,11 @@ env:
     - MYSQL_HOST="127.0.0.1"
     - MYSQL_PORT="3406"
     - PCT_TEST_MYSQL_DSN="${MYSQL_USER}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/?parseTime=true"
+  matrix:
+    - MYSQL_IMAGE=mysql:5.6
+    - MYSQL_IMAGE=mysql:5.7
+    - MONGODB_IMAGE=mongo:3.2
+    - MONGODB_IMAGE=mongo:3.4
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,16 @@ sudo: required
 
 language: go
 
-go:
-  - 1.7.x
-  - 1.8.x
+matrix:
+  include:
+    - go: 1.8.x
+      env:
+        matrix:
+          - MYSQL_IMAGE=mysql:5.6
+          - MYSQL_IMAGE=mysql:5.7
+          - MONGODB_IMAGE=mongo:3.2
+          - MONGODB_IMAGE=mongo:3.4
+    - go: 1.7.x
 
 services:
   - mysql
@@ -16,11 +23,6 @@ env:
     - MYSQL_HOST="127.0.0.1"
     - MYSQL_PORT="3406"
     - PCT_TEST_MYSQL_DSN="${MYSQL_USER}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/?parseTime=true"
-  matrix:
-    - MYSQL_IMAGE=mysql:5.6
-    - MYSQL_IMAGE=mysql:5.7
-    - MONGODB_IMAGE=mongo:3.2
-    - MONGODB_IMAGE=mongo:3.4
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,14 @@ services:
   - docker
 
 env:
-  - MYSQL_VERSION=5.6
-  - MYSQL_VERSION=5.7
   global:
     - MYSQL_USER="root"
     - MYSQL_HOST="127.0.0.1"
     - MYSQL_PORT="3406"
     - PCT_TEST_MYSQL_DSN="${MYSQL_USER}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/?parseTime=true"
+  matrix:
+    - MYSQL_VERSION=5.6
+    - MYSQL_VERSION=5.7
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 language: go
 
 go:
@@ -8,6 +6,7 @@ go:
 
 services:
   - mongodb
+  - docker
 
 env:
   - MYSQL_VERSION=5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ services:
 env:
   - MYSQL_VERSION=5.6
   - MYSQL_VERSION=5.7
-
-env:
   global:
     - MYSQL_USER="root"
     - MYSQL_HOST="127.0.0.1"
@@ -25,9 +23,9 @@ env:
 addons:
   apt:
     sources:
-      - sourceline: 'deb http://repo.percona.com/apt precise testing'
+      - sourceline: 'deb http://repo.percona.com/apt trusty testing'
         key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x8507EFA5'
-      - mongodb-3.2-precise
+      - mongodb-3.2-trusty
     packages:
       - percona-toolkit
       - mongodb-org

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 env:
   global:
     - MYSQL_USER="root"
-    - MYSQL_HOST="localhost"
+    - MYSQL_HOST="127.0.0.1"
     - MYSQL_PORT="3406"
     - PCT_TEST_MYSQL_DSN="${MYSQL_USER}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/?parseTime=true"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,27 +18,28 @@ env:
     - MYSQL_PORT="3406"
     - PCT_TEST_MYSQL_DSN="${MYSQL_USER}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/?parseTime=true"
   matrix:
-    - MYSQL_VERSION=5.6
-    - MYSQL_VERSION=5.7
+    - MYSQL_IMAGE=mysql:5.6
+    - MYSQL_IMAGE=mysql:5.7
+    - MONGODB_IMAGE=mongo:3.2
+    - MONGODB_IMAGE=mongo:3.4
 
 addons:
   apt:
     sources:
       - sourceline: 'deb http://repo.percona.com/apt trusty testing'
         key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x8507EFA5'
-      - mongodb-3.2-trusty
     packages:
       - percona-toolkit
-      - mongodb-org
 
 install:
-  - sh .travis-install-mysql.sh
   - go get -u github.com/Masterminds/glide
   # remove vendor dir and re-fetch it to check later if it's correct with `git diff --exit-code`
   - rm -rf vendor/
   - glide install
 
 before_script:
+  # run docker containers
+  - docker-compose up -d
   # check if vendor dir is correct
   - git diff --exit-code
   # turn on profiling on mongo instance

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ matrix:
     - go: 1.7.x
   include:
     - go: 1.7.x
-      env: MYSQL_IMAGE=mysql:5.7 MONGODB_IMAGE=mongo:3.5
+      env: *global MYSQL_IMAGE=mysql:5.7 MONGODB_IMAGE=mongo:3.5
 
 services:
   - mysql
   - docker
 
 env:
-  global:
+  global: &global
     - MYSQL_USER="root"
     - MYSQL_HOST="127.0.0.1"
     - MYSQL_PORT="3406"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ go:
 matrix:
   exclude:
     - go: 1.7.x
+  include:
+    - go: 1.7.x
+      env: MYSQL_IMAGE=mysql:5.7 MONGODB_IMAGE=mongo:3.5
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ services: &services
   - docker
 
 env:
-  global: &global
+  global:
     - MYSQL_USER="root"
     - MYSQL_HOST="127.0.0.1"
     - MYSQL_PORT="3406"
     - PCT_TEST_MYSQL_DSN="${MYSQL_USER}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/?parseTime=true"
-  matrix: &matrix
+  matrix:
     - MYSQL_IMAGE=mysql:5.5
     - MYSQL_IMAGE=mysql:5.6
     - MYSQL_IMAGE=mysql:5.7
@@ -28,15 +28,11 @@ env:
 matrix:
   include:
     - go: 1.7.x
-      services: *services
       env:
-        global: *global
-        matrix: *matrix
+        - MYSQL_IMAGE=mysql:5.7 MONGODB_IMAGE=mongo:3.2
     - go: tip
-      services: *services
       env:
-        global: *global
-        matrix: *matrix
+        - MYSQL_IMAGE=mysql:5.7 MONGODB_IMAGE=mongo:3.2
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ matrix:
     - MYSQL_IMAGE=mysql:8.0
     - MONGODB_IMAGE=mongo:3.0
     - MONGODB_IMAGE=mongo:3.5
+  fast_finish: true
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language: go
 
 go:
@@ -6,6 +8,7 @@ go:
 
 services:
   - mongodb
+  - mysql
   - docker
 
 env:
@@ -16,7 +19,7 @@ env:
   global:
     - MYSQL_USER="root"
     - MYSQL_HOST="localhost"
-    - MYSQL_PORT="3306"
+    - MYSQL_PORT="3406"
     - PCT_TEST_MYSQL_DSN="${MYSQL_USER}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/?parseTime=true"
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ matrix:
       env:
         global: *global
         matrix: *matrix
-  include:
     - go: tip
       services: *services
       env:
@@ -42,7 +41,7 @@ matrix:
 addons:
   apt:
     sources:
-      - sourceline: 'deb http://repo.percona.com/apt trusty testing'
+      - sourceline: "deb http://repo.percona.com/apt $(lsb_release -s -c) testing"
         key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x8507EFA5'
     packages:
       - percona-toolkit

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,7 @@ env:
 matrix:
   include:
     - go: 1.7.x
-      env:
-        - MYSQL_IMAGE=mysql:5.7 MONGODB_IMAGE=mongo:3.4
     - go: tip
-      env:
-        - MYSQL_IMAGE=mysql:5.7 MONGODB_IMAGE=mongo:3.4
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ matrix:
   include:
     - go: 1.7.x
       env:
-        - MYSQL_IMAGE=mysql:5.7 MONGODB_IMAGE=mongo:3.2
+        - MYSQL_IMAGE=mysql:5.7 MONGODB_IMAGE=mongo:3.4
     - go: tip
       env:
-        - MYSQL_IMAGE=mysql:5.7 MONGODB_IMAGE=mongo:3.2
+        - MYSQL_IMAGE=mysql:5.7 MONGODB_IMAGE=mongo:3.4
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,15 @@ sudo: required
 language: go
 
 go:
-  - 1.7.x
-  - 1.8.x
-
-matrix:
-  exclude:
-    - go: 1.7.x
-  include:
-    - go: 1.7.x
-      env: *global MYSQL_IMAGE=mysql:5.7 MONGODB_IMAGE=mongo:3.5
+  - 1.8
+  - tip
 
 services:
   - mysql
   - docker
 
 env:
-  global: &global
+  global:
     - MYSQL_USER="root"
     - MYSQL_HOST="127.0.0.1"
     - MYSQL_PORT="3406"
@@ -69,3 +62,8 @@ notifications:
   email:
     on_success: change
     on_failure: change
+  slack:
+    on_success: change
+    on_failure: change
+    rooms:
+      secure: A/jke9SzibxoGc0H86z5fnGKoLr6xTPBNUcjLMVJ2xzqp8HX90gOdWKenooCu6tyJ0gXX8nUgIOQWsupICy2P2HPGXXKonY4Lq1qRPbxXnlqweaoTf2IZ8SmQeyP6TvNZF9978YRLqRBmJXzq7dcZCF2Gr/1XLPDCNIVJcKgG+heVUubt6q8EnIzB4OYKwUJwZ2ORzleLwqzs8ViB5ffmOXmAVd80rUTcCOailKE4+ML+CQO1MLbGxbdVjacivjM0cvXoibRZF5bhUsg7qoszaWJidJjX9UtW9rRKyPuh1vh1HFgayxmWNeiqe7yyIwGZU37Gnten+4XsVpKYxSOfRWz8TNu01jdDs7e8RgJ29OCwVG88y/yxrBtDlhjsKvy7owV1eAH63YVUJzgoVQZKUt04LAKTMxjEZKBb7o7+GdmSHQWPj8NNmcPEWBwSg99yU3xTQXefgLjqiCQTTNaiNEa1JgPNroKXzAcjJ12qpY5F5MWPFZ2ndTOL2kVEn4iqV7t6bresISXAZKJn+IrjUdZ+ZBr48zcnO7rgWGvszScDWt3oqjRlCbwxXWTL8VoDouylGVAJTUHxo07Bs307cwYiLsUp/2hPvcY2ELXrQXTqk3ZHJkMHa4U+nNvXY9RYNNqFmvAnUCHG6JfBda4b0SCjbCINjQVMCsF5DSXua8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,8 @@ env:
     - MYSQL_IMAGE=mysql:5.5
     - MYSQL_IMAGE=mysql:5.6
     - MYSQL_IMAGE=mysql:5.7
-    - MYSQL_IMAGE=mysql:8.0
-    - MONGODB_IMAGE=mongo:3.0
     - MONGODB_IMAGE=mongo:3.2
     - MONGODB_IMAGE=mongo:3.4
-    - MONGODB_IMAGE=mongo:3.5
 
 matrix:
   include:
@@ -34,11 +31,6 @@ matrix:
     - go: tip
       env:
         - MYSQL_IMAGE=mysql:5.7 MONGODB_IMAGE=mongo:3.2
-  allow_failures:
-    - MYSQL_IMAGE=mysql:8.0
-    - MONGODB_IMAGE=mongo:3.0
-    - MONGODB_IMAGE=mongo:3.5
-  fast_finish: true
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ matrix:
     - go: tip
       env:
         - MYSQL_IMAGE=mysql:5.7 MONGODB_IMAGE=mongo:3.2
+  allow_failures:
+    - MYSQL_IMAGE=mysql:8.0
+    - MONGODB_IMAGE=mongo:3.0
+    - MONGODB_IMAGE=mongo:3.5
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ go:
 
 services:
   - mongodb
-  - mysql
+
+env:
+  - MYSQL_VERSION=5.6
+  - MYSQL_VERSION=5.7
 
 env:
   global:
@@ -26,6 +29,7 @@ addons:
       - mongodb-org
 
 install:
+  - sh .travis-install-mysql.sh
   - go get -u github.com/Masterminds/glide
   # remove vendor dir and re-fetch it to check later if it's correct with `git diff --exit-code`
   - rm -rf vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,12 @@ env:
     - MYSQL_IMAGE=mysql:5.5
     - MYSQL_IMAGE=mysql:5.6
     - MYSQL_IMAGE=mysql:5.7
+    - MYSQL_IMAGE=percona/percona-server:5.6
+    - MYSQL_IMAGE=percona/percona-server:5.7
     - MONGODB_IMAGE=mongo:3.2
     - MONGODB_IMAGE=mongo:3.4
+    - MONGODB_IMAGE=percona/percona-server-mongodb:3.2
+    - MONGODB_IMAGE=percona/percona-server-mongodb:3.4
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ sudo: required
 
 language: go
 
+go:
+  - 1.7.x
+  - 1.8.x
+
+matrix:
+  exclude:
+    - go: 1.7.x
+
 services:
   - mysql
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,14 @@ env:
     - MYSQL_PORT="3406"
     - PCT_TEST_MYSQL_DSN="${MYSQL_USER}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/?parseTime=true"
   matrix:
+    - MYSQL_IMAGE=mysql:5.5
     - MYSQL_IMAGE=mysql:5.6
     - MYSQL_IMAGE=mysql:5.7
+    - MYSQL_IMAGE=mysql:8.0
+    - MONGODB_IMAGE=mongo:3.0
     - MONGODB_IMAGE=mongo:3.2
     - MONGODB_IMAGE=mongo:3.4
+    - MONGODB_IMAGE=mongo:3.5
 
 addons:
   apt:

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -33,6 +33,7 @@ import (
 	pctCmd "github.com/percona/qan-agent/pct/cmd"
 	"github.com/percona/qan-agent/test"
 	"github.com/percona/qan-agent/test/mock"
+	"github.com/percona/qan-agent/test/rootdir"
 	"github.com/stretchr/testify/assert"
 	. "gopkg.in/check.v1"
 )
@@ -40,7 +41,7 @@ import (
 // Hook gocheck into the "go test" runner.
 func Test(t *testing.T) { TestingT(t) }
 
-var sample = test.RootDir + "/agent"
+var sample = rootdir.RootDir() + "/test/agent"
 
 type AgentTestSuite struct {
 	tmpDir     string

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/percona/qan-agent/pct"
 	"github.com/percona/qan-agent/test"
 	"github.com/percona/qan-agent/test/mock"
+	"github.com/percona/qan-agent/test/rootdir"
 	"github.com/stretchr/testify/assert"
 	. "gopkg.in/check.v1"
 )
@@ -42,7 +43,7 @@ import (
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) { TestingT(t) }
 
-var sample = test.RootDir + "/qan/"
+var sample = rootdir.RootDir() + "/test/qan/"
 
 /////////////////////////////////////////////////////////////////////////////
 // DiskvSpooler test suite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  mysql:
+    image: ${MYSQL_IMAGE:-mysql:5.7}
+    ports:
+      - ${MYSQL_HOST:-127.0.0.1}:${MYSQL_PORT:-3306}:3306
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+  mongo:
+    image: ${MONGODB_IMAGE:-mongo:3.4}
+    ports:
+      - ${MONGODB_HOST:-127.0.0.1}:${MONGODB_PORT:-27017}:27017

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '3'
 services:
   mysql:
-    image: ${MYSQL_IMAGE:-mysql:5.7}
+    image: ${MYSQL_IMAGE:-percona/percona-server:5.7}
     ports:
       - ${MYSQL_HOST:-127.0.0.1}:${MYSQL_PORT:-3306}:3306
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
   mongo:
-    image: ${MONGODB_IMAGE:-mongo:3.4}
+    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb:3.4}
     ports:
       - ${MONGODB_HOST:-127.0.0.1}:${MONGODB_PORT:-27017}:27017

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/percona/qan-agent/pct"
 	"github.com/percona/qan-agent/test"
 	"github.com/percona/qan-agent/test/mock"
+	"github.com/percona/qan-agent/test/rootdir"
 	. "gopkg.in/check.v1"
 )
 
@@ -144,9 +145,9 @@ func (s *ManagerTestSuite) TestStartAndUpdate(t *C) {
 	mysqlInstanceFile := pct.Basedir.InstanceFile("BBB")
 
 	var err error
-	err = test.CopyFile(filepath.Join(test.RootDir, "instances/001/os-AAA.json"), pct.Basedir.InstanceFile("AAA"))
+	err = test.CopyFile(filepath.Join(rootdir.RootDir(), "test/instances/001/os-AAA.json"), pct.Basedir.InstanceFile("AAA"))
 	t.Assert(err, IsNil)
-	err = test.CopyFile(filepath.Join(test.RootDir, "instances/001/mysql-BBB.json"), mysqlInstanceFile)
+	err = test.CopyFile(filepath.Join(rootdir.RootDir(), "test/instances/001/mysql-BBB.json"), mysqlInstanceFile)
 	t.Assert(err, IsNil)
 
 	bytes, err := ioutil.ReadFile(mysqlInstanceFile)

--- a/pct/sys.go
+++ b/pct/sys.go
@@ -194,7 +194,7 @@ func AtLeastVersion(v1, v2 string) (bool, error) {
 func ToBool(s string) bool {
 	s = strings.ToLower(s)
 	switch s {
-	case "yes", "true", "on":
+	case "yes", "true", "on", "1":
 		return true
 	default:
 		return false

--- a/qan/analyzer/analyzer.go
+++ b/qan/analyzer/analyzer.go
@@ -15,7 +15,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
-package qan
+package analyzer
 
 import (
 	"github.com/percona/pmm/proto"

--- a/qan/analyzer/factory/factory.go
+++ b/qan/analyzer/factory/factory.go
@@ -26,7 +26,7 @@ import (
 	"github.com/percona/qan-agent/instance"
 	"github.com/percona/qan-agent/mrms"
 	"github.com/percona/qan-agent/pct"
-	"github.com/percona/qan-agent/qan"
+	"github.com/percona/qan-agent/qan/analyzer"
 	mongoAnalyzer "github.com/percona/qan-agent/qan/analyzer/mongo"
 	mysqlAnalyzer "github.com/percona/qan-agent/qan/analyzer/mysql"
 	"github.com/percona/qan-agent/ticker"
@@ -65,7 +65,7 @@ func New(
 	return f
 }
 
-func (f *Factory) Make(analyzerType, analyzerName string, protoInstance proto.Instance) (qan.Analyzer, error) {
+func (f *Factory) Make(analyzerType, analyzerName string, protoInstance proto.Instance) (analyzer.Analyzer, error) {
 	logger := pct.NewLogger(f.logChan, analyzerName)
 
 	// Expose some global services to plugins

--- a/qan/analyzer/mongo/mongo.go
+++ b/qan/analyzer/mongo/mongo.go
@@ -10,13 +10,13 @@ import (
 	pc "github.com/percona/pmm/proto/config"
 	"github.com/percona/qan-agent/data"
 	"github.com/percona/qan-agent/pct"
-	"github.com/percona/qan-agent/qan"
+	"github.com/percona/qan-agent/qan/analyzer"
 	"github.com/percona/qan-agent/qan/analyzer/mongo/collector"
 	"github.com/percona/qan-agent/qan/analyzer/mongo/parser"
 	"github.com/percona/qan-agent/qan/analyzer/mongo/sender"
 )
 
-func New(ctx context.Context, protoInstance proto.Instance) qan.Analyzer {
+func New(ctx context.Context, protoInstance proto.Instance) analyzer.Analyzer {
 	// Get available services from ctx
 	services, _ := ctx.Value("services").(map[string]interface{})
 
@@ -145,7 +145,7 @@ func (m *MongoAnalyzer) Status() map[string]string {
 // Stop stops running analyzer, waits until it stops
 func (m *MongoAnalyzer) Stop() error {
 	m.Lock()
-	m.Unlock()
+	defer m.Unlock()
 	if !m.running {
 		return nil
 	}

--- a/qan/analyzer/mysql/mysql.go
+++ b/qan/analyzer/mysql/mysql.go
@@ -11,7 +11,7 @@ import (
 	"github.com/percona/qan-agent/mrms"
 	"github.com/percona/qan-agent/mysql"
 	"github.com/percona/qan-agent/pct"
-	"github.com/percona/qan-agent/qan"
+	"github.com/percona/qan-agent/qan/analyzer"
 	"github.com/percona/qan-agent/qan/analyzer/mysql/config"
 	"github.com/percona/qan-agent/qan/analyzer/mysql/factory"
 	"github.com/percona/qan-agent/qan/analyzer/mysql/iter"
@@ -21,7 +21,7 @@ import (
 	"github.com/percona/qan-agent/ticker"
 )
 
-func New(ctx context.Context, protoInstance proto.Instance) qan.Analyzer {
+func New(ctx context.Context, protoInstance proto.Instance) analyzer.Analyzer {
 	// Get available services from ctx
 	services, _ := ctx.Value("services").(map[string]interface{})
 
@@ -61,7 +61,7 @@ func New(ctx context.Context, protoInstance proto.Instance) qan.Analyzer {
 type MySQLAnalyzer struct {
 	// on initialization config and analyzer are uninitialized
 	config   pc.QAN
-	analyzer qan.Analyzer
+	analyzer analyzer.Analyzer
 	// services initialized in New
 	protoInstance           proto.Instance
 	logger                  *pct.Logger
@@ -197,18 +197,18 @@ func (m *MySQLAnalyzer) GetDefaults(uuid string) map[string]interface{} {
 	mysqlConn := m.mysqlConnFactory.Make(mysqlInstance.DSN)
 	config.ReadMySQLConfig(mysqlConn) // Read current values
 	return map[string]interface{}{
-		"CollectFrom":             collectFrom,
-		"Interval":                interval,
-		"LongQueryTime":           config.DEFAULT_LONG_QUERY_TIME,
-		"MaxSlowLogSize":          config.DEFAULT_MAX_SLOW_LOG_SIZE,
-		"RemoveOldSlowLogs":       config.DEFAULT_REMOVE_OLD_SLOW_LOGS,
-		"ExampleQueries":          exampleQueries,
-		"SlowLogVerbosity":        config.DEFAULT_SLOW_LOG_VERBOSITY,
-		"RateLimit":               config.DEFAULT_RATE_LIMIT,
-		"LogSlowAdminStatements":  config.DEFAULT_LOG_SLOW_ADMIN_STATEMENTS,
-		"LogSlowSlaveStatemtents": config.DEFAULT_LOG_SLOW_SLAVE_STATEMENTS,
-		"WorkerRunTime":           config.DEFAULT_WORKER_RUNTIME,
-		"ReportLimit":             config.DEFAULT_REPORT_LIMIT,
+		"CollectFrom":            collectFrom,
+		"Interval":               interval,
+		"LongQueryTime":          config.DEFAULT_LONG_QUERY_TIME,
+		"MaxSlowLogSize":         config.DEFAULT_MAX_SLOW_LOG_SIZE,
+		"RemoveOldSlowLogs":      config.DEFAULT_REMOVE_OLD_SLOW_LOGS,
+		"ExampleQueries":         exampleQueries,
+		"SlowLogVerbosity":       config.DEFAULT_SLOW_LOG_VERBOSITY,
+		"RateLimit":              config.DEFAULT_RATE_LIMIT,
+		"LogSlowAdminStatements": config.DEFAULT_LOG_SLOW_ADMIN_STATEMENTS,
+		"LogSlowSlaveStatements": config.DEFAULT_LOG_SLOW_SLAVE_STATEMENTS,
+		"WorkerRunTime":          config.DEFAULT_WORKER_RUNTIME,
+		"ReportLimit":            config.DEFAULT_REPORT_LIMIT,
 	}
 }
 

--- a/qan/manager.go
+++ b/qan/manager.go
@@ -31,6 +31,7 @@ import (
 	pc "github.com/percona/pmm/proto/config"
 	"github.com/percona/qan-agent/instance"
 	"github.com/percona/qan-agent/pct"
+	"github.com/percona/qan-agent/qan/analyzer"
 )
 
 const (
@@ -46,14 +47,14 @@ var (
 // as configured.
 type AnalyzerInstance struct {
 	setConfig pc.QAN
-	analyzer  Analyzer
+	analyzer  analyzer.Analyzer
 }
 
 // A Manager runs AnalyzerInstances, one per MySQL instance as configured.
 type Manager struct {
 	logger          *pct.Logger
 	instanceRepo    *instance.Repo
-	analyzerFactory AnalyzerFactory
+	analyzerFactory analyzer.AnalyzerFactory
 	// --
 	mux       *sync.RWMutex
 	running   bool
@@ -64,7 +65,7 @@ type Manager struct {
 func NewManager(
 	logger *pct.Logger,
 	instanceRepo *instance.Repo,
-	analyzerFactory AnalyzerFactory,
+	analyzerFactory analyzer.AnalyzerFactory,
 ) *Manager {
 	m := &Manager{
 		logger:          logger,

--- a/qan/manager_test.go
+++ b/qan/manager_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/percona/pmm/proto"
@@ -34,6 +35,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	. "gopkg.in/check.v1"
 )
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
 
 type ManagerTestSuite struct {
 	logChan       chan proto.LogEntry

--- a/qan/qan_test.go
+++ b/qan/qan_test.go
@@ -15,13 +15,154 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
-package qan_test
+package qan
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
-	. "gopkg.in/check.v1"
+	"fmt"
+	"github.com/percona/pmm/proto"
+	pc "github.com/percona/pmm/proto/config"
+	"github.com/percona/qan-agent/instance"
+	"github.com/percona/qan-agent/mysql"
+	"github.com/percona/qan-agent/pct"
+	"github.com/percona/qan-agent/qan/analyzer"
+	"github.com/percona/qan-agent/qan/analyzer/factory"
+	"github.com/percona/qan-agent/test"
+	"github.com/percona/qan-agent/test/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
+// TestWithRealMySQL runs tests against real MySQL server
+func TestWithRealMySQL(t *testing.T) {
+	dsn := os.Getenv("PCT_TEST_MYSQL_DSN")
+	require.NotEmpty(t, dsn, "PCT_TEST_MYSQL_DSN is not set")
+
+	// Init pct.Basedir
+	tmpDir, err := ioutil.TempDir("/tmp", "agent-test")
+	require.Nil(t, err)
+	if err := pct.Basedir.Init(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Create dependencies for Manager
+	logChan := make(chan proto.LogEntry, 1000)
+	dataChan := make(chan interface{})
+	spool := mock.NewSpooler(dataChan)
+	clock := mock.NewClock()
+	mrm := mock.NewMrmsMonitor()
+	logger := pct.NewLogger(logChan, "TestManager_GetDefaults")
+	links := map[string]string{}
+	api := mock.NewAPI("http://localhost", "http://localhost", "abc-123-def", links)
+	instanceRepo := instance.NewRepo(logger, "", api)
+	protoInstance := proto.Instance{
+		Subsystem: "mysql",
+		UUID:      "3130000000000000",
+		Name:      "db01",
+		DSN:       dsn,
+	}
+	err = instanceRepo.Add(protoInstance, false)
+	assert.Nil(t, err)
+	defer instanceRepo.Remove(protoInstance.UUID)
+	analyzerFactory := factory.New(
+		logChan,
+		spool,
+		clock,
+		mrm,
+		instanceRepo,
+	)
+
+	// Write a realistic qan.conf config to disk.
+	pcQANSetExpected := pc.QAN{
+		UUID:          protoInstance.UUID,
+		CollectFrom:   "slowlog",
+		Interval:      300,
+		WorkerRunTime: 270,
+	}
+	err = pct.Basedir.WriteConfig("qan-"+protoInstance.UUID, &pcQANSetExpected)
+	assert.Nil(t, err)
+
+	t.Run("real-mysql", func(t *testing.T) {
+		testGetDefaultsBoolValues(t, logger, instanceRepo, analyzerFactory, protoInstance)
+	})
+}
+
+// testGetDefaultsBoolValues verifies if value for MySQL bool variable is properly converted to json bool
+func testGetDefaultsBoolValues(
+	t *testing.T,
+	logger *pct.Logger,
+	instanceRepo *instance.Repo,
+	analyzerFactory analyzer.AnalyzerFactory,
+	protoInstance proto.Instance,
+) {
+	// Create new Manager
+	m := NewManager(
+		logger,
+		instanceRepo,
+		analyzerFactory,
+	)
+
+	// Create new MySQL connection
+	conn := mysql.NewConnection(protoInstance.DSN)
+	err := conn.Connect()
+	require.Nil(t, err)
+	defer conn.Close()
+
+	// Start the manager and analyzer.
+	err = m.Start()
+	require.Nil(t, err)
+	test.WaitStatus(1, m, "qan", "Running")
+
+	keys := []struct {
+		db   string
+		json string
+	}{
+		{"log_slow_admin_statements", "LogSlowAdminStatements"},
+		{"log_slow_slave_statements", "LogSlowSlaveStatements"},
+	}
+
+	t.Run("variables", func(t *testing.T) {
+		for i := range keys {
+			// create local variable
+			i := i
+
+			t.Run(keys[i].json, func(t *testing.T) {
+				t.Parallel()
+
+				// GetDefaults returns current configuration
+				// let's be sure log_slow_slave_statements=0 returns `false`
+				err = conn.Set([]mysql.Query{
+					{
+						Set: fmt.Sprintf("SET GLOBAL %s=0", keys[i].db),
+					},
+				})
+				require.Nil(t, err)
+				got := m.GetDefaults(protoInstance.UUID)
+				assert.Equal(t, false, got[keys[i].json])
+
+				// GetDefaults returns current configuration
+				// let's be sure log_slow_slave_statements=1 returns `true`
+				err = conn.Set([]mysql.Query{
+					{
+						Set: fmt.Sprintf("SET GLOBAL %s=1", keys[i].db),
+					},
+				})
+				require.Nil(t, err)
+				got = m.GetDefaults(protoInstance.UUID)
+				assert.Equal(t, true, got[keys[i].json])
+			})
+		}
+	})
+
+	// Stop the manager.
+	err = m.Stop()
+	assert.Nil(t, err)
+}

--- a/query/plugin/os/os_test.go
+++ b/query/plugin/os/os_test.go
@@ -24,13 +24,14 @@ import (
 
 	"github.com/percona/pmm/proto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandle(t *testing.T) {
 	t.Parallel()
 
 	dsn := os.Getenv("PCT_TEST_MYSQL_DSN")
-	assert.NotEmpty(t, dsn, "PCT_TEST_MYSQL_DSN is not set")
+	require.NotEmpty(t, dsn, "PCT_TEST_MYSQL_DSN is not set")
 
 	fs := []struct {
 		provider func() (cmd *proto.Cmd, in proto.Instance)

--- a/test/app.go
+++ b/test/app.go
@@ -18,44 +18,16 @@
 package test
 
 import (
-	"crypto"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/sha256"
-	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/percona/pmm/proto"
 )
-
-var RootDir string
-
-func init() {
-	log.SetFlags(log.Ltime | log.Lmicroseconds | log.Lshortfile)
-
-	_, filename, _, _ := runtime.Caller(1)
-	dir := filepath.Dir(filename)
-
-	for i := 0; i < 3; i++ {
-		dir = dir + "/../"
-		if FileExists(dir + ".git") {
-			RootDir = filepath.Clean(dir + "test")
-			break
-		}
-	}
-	if RootDir == "" {
-		log.Panic("Cannot find repo root dir")
-	}
-}
 
 func FileExists(file string) bool {
 	_, err := os.Stat(file)
@@ -88,12 +60,6 @@ func GetStatus(sendChan chan *proto.Cmd, recvChan chan *proto.Reply) map[string]
 	}
 
 	return map[string]string{}
-}
-
-func WriteData(data interface{}, filename string) {
-	bytes, _ := json.MarshalIndent(data, "", " ")
-	bytes = append(bytes, 0x0A) // newline
-	ioutil.WriteFile(filename, bytes, os.ModePerm)
 }
 
 func DrainLogChan(c chan proto.LogEntry) {
@@ -170,71 +136,9 @@ func DrainDataChan(c chan []byte) {
 	}
 }
 
-func FileSize(fileName string) (int64, error) {
-	stat, err := os.Stat(fileName)
-	if err != nil {
-		return -1, err
-	}
-	return stat.Size(), nil
-}
-
-func Dump(v interface{}) {
-	bytes, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		fmt.Printf("Error dumping data struct: %s\n", err)
-	}
-	fmt.Println(string(bytes))
-}
-
-func Debug(logChan chan *proto.LogEntry) {
-	for l := range logChan {
-		log.Println(l)
-	}
-}
-
 func CopyFile(src, dst string) error {
 	cmd := exec.Command("cp", src, dst)
 	return cmd.Run()
-}
-
-func Sign(file string) ([]byte, []byte, error) {
-	data, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	key, err := privkey(RootDir + "/pct/key.pem")
-	if err != nil {
-		return nil, nil, fmt.Errorf("privkey: %s", err)
-	}
-
-	h := sha256.New()
-	h.Write(data)
-
-	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, h.Sum(nil))
-	if err != nil {
-		return nil, nil, err
-	}
-	return data, sig, nil
-}
-
-func privkey(file string) (key *rsa.PrivateKey, err error) {
-	buf, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, err
-	}
-
-	p, _ := pem.Decode(buf)
-	if p == nil {
-		return nil, fmt.Errorf("Invalid private key")
-	}
-
-	der, err := x509.DecryptPEMBlock(p, []byte("percona cloud tools"))
-	if err != nil {
-		return nil, fmt.Errorf("x509.DecryptPEMBlock: %s", err)
-	}
-
-	return x509.ParsePKCS1PrivateKey(der)
 }
 
 func ClearDir(path ...string) error {

--- a/test/mock/qan_analyzer.go
+++ b/test/mock/qan_analyzer.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/percona/pmm/proto"
 	pc "github.com/percona/pmm/proto/config"
-	"github.com/percona/qan-agent/qan"
+	"github.com/percona/qan-agent/qan/analyzer"
 )
 
 type QanAnalyzer struct {
@@ -118,11 +118,11 @@ type AnalyzerArgs struct {
 
 type QanAnalyzerFactory struct {
 	Args      []AnalyzerArgs
-	analyzers []qan.Analyzer
+	analyzers []analyzer.Analyzer
 	n         int
 }
 
-func NewQanAnalyzerFactory(a ...qan.Analyzer) *QanAnalyzerFactory {
+func NewQanAnalyzerFactory(a ...analyzer.Analyzer) *QanAnalyzerFactory {
 	f := &QanAnalyzerFactory{
 		Args:      []AnalyzerArgs{},
 		analyzers: a,
@@ -135,7 +135,7 @@ func (f *QanAnalyzerFactory) Make(
 	analyzerName string,
 	protoInstance proto.Instance,
 ) (
-	qan.Analyzer,
+	analyzer.Analyzer,
 	error,
 ) {
 	if f.n < len(f.analyzers) {


### PR DESCRIPTION
* PMM-949:
  ```diff --git a/pct/sys.go b/pct/sys.go
  index 75d280e..b022bb8 100644
  --- a/pct/sys.go
  +++ b/pct/sys.go
  @@ -194,7 +194,7 @@ func AtLeastVersion(v1, v2 string) (bool, error) {
   func ToBool(s string) bool {
          s = strings.ToLower(s)
          switch s {
  -       case "yes", "true", "on":
  +       case "yes", "true", "on", "1":
                  return true
          default:
                  return false
  ```
* Typo
  ```diff --git a/qan/analyzer/mysql/mysql.go b/qan/analyzer/mysql/mysql.go
  index b71b3a9..dc0f4c6 100644
  --- a/qan/analyzer/mysql/mysql.go
  +++ b/qan/analyzer/mysql/mysql.go
  @@ -197,18 +197,18 @@ func (m *MySQLAnalyzer) GetDefaults(uuid string) map[string]interface{} {
          mysqlConn := m.mysqlConnFactory.Make(mysqlInstance.DSN)
          config.ReadMySQLConfig(mysqlConn) // Read current values
          return map[string]interface{}{
                  "CollectFrom":            collectFrom,
                  "Interval":               interval,
                  "LongQueryTime":          config.DEFAULT_LONG_QUERY_TIME,
                  "MaxSlowLogSize":         config.DEFAULT_MAX_SLOW_LOG_SIZE,
                  "RemoveOldSlowLogs":      config.DEFAULT_REMOVE_OLD_SLOW_LOGS,
                  "ExampleQueries":         exampleQueries,
                  "SlowLogVerbosity":       config.DEFAULT_SLOW_LOG_VERBOSITY,
                  "RateLimit":              config.DEFAULT_RATE_LIMIT,
                  "LogSlowAdminStatements": config.DEFAULT_LOG_SLOW_ADMIN_STATEMENTS,
  -               "LogSlowSlaveStatemtents":config.DEFAULT_LOG_SLOW_SLAVE_STATEMENTS,
  +               "LogSlowSlaveStatements": config.DEFAULT_LOG_SLOW_SLAVE_STATEMENTS,
                  "WorkerRunTime":          config.DEFAULT_WORKER_RUNTIME,
                  "ReportLimit":            config.DEFAULT_REPORT_LIMIT,
          }
   }
  ```
* TravisCI: Testing on multiple MySQL and MongoDB versions (travis matrix) with MySQL and MongoDB provided by docker. 🍻 to @AlekSi for cool usage of `docker-compose`. However we should probably switch at some point to https://github.com/ory/dockertest
  ![build__339_-_percona_qan-agent_-_travis_ci](https://user-images.githubusercontent.com/450355/28177429-0f2ef5f8-67fb-11e7-9a34-93f9f164dfa2.png)
* Add slack notifications
* Some cleanups
