### PR TITLE
PMM-1472: add missing timeout

### DIFF
--- a/qan/analyzer/mongo/profiler/aggregator/aggregator.go
+++ b/qan/analyzer/mongo/profiler/aggregator/aggregator.go
@@ -1,8 +1,8 @@
 package aggregator
 
 import (
-	"time"
 	"strings"
+	"time"
 
 	"github.com/percona/go-mysql/event"
 	"github.com/percona/percona-toolkit/src/go/mongolib/fingerprinter"

--- a/qan/analyzer/mongo/profiler/collector/collector.go
+++ b/qan/analyzer/mongo/profiler/collector/collector.go
@@ -130,6 +130,7 @@ func getProfile(
 	dialInfo *pmgo.DialInfo,
 	dialer pmgo.Dialer,
 ) string {
+	dialInfo.Timeout = MgoTimeoutDialInfo
 	session, err := dialer.DialWithInfo(dialInfo)
 	if err != nil {
 		return fmt.Sprintf("%s", err)
@@ -189,7 +190,6 @@ func start(
 	// signal WaitGroup when goroutine finished
 	defer wg.Done()
 
-	dialInfo.Timeout = MgoTimeoutDialInfo
 	firstTry := true
 	for {
 		// make a connection and collect data
@@ -227,6 +227,7 @@ func connectAndCollect(
 	stats *stats,
 	ready *sync.Cond,
 ) {
+	dialInfo.Timeout = MgoTimeoutDialInfo
 	session, err := dialer.DialWithInfo(dialInfo)
 	if err != nil {
 		return

--- a/qan/analyzer/mongo/profiler/monitors.go
+++ b/qan/analyzer/mongo/profiler/monitors.go
@@ -9,6 +9,7 @@ import (
 )
 
 const (
+	MgoTimeoutDialInfo      = 5 * time.Second
 	MgoTimeoutSessionSync   = 5 * time.Second
 	MgoTimeoutSessionSocket = 5 * time.Second
 )
@@ -82,7 +83,7 @@ func (self *monitors) MonitorAll() error {
 		self.monitors[dbName] = m
 	}
 
-	// if databases is no longer present then stop monitoring it
+	// if database is no longer present then stop monitoring it
 	for dbName := range self.monitors {
 		if _, ok := databases[dbName]; !ok {
 			self.monitors[dbName].Stop()
@@ -130,10 +131,10 @@ func (self *monitors) GetAll() map[string]*monitor {
 }
 
 func listDatabases(dialInfo *pmgo.DialInfo, dialer pmgo.Dialer) ([]string, error) {
+	dialInfo.Timeout = MgoTimeoutDialInfo
 	session, err := dialer.DialWithInfo(dialInfo)
 	if err != nil {
 		return nil, err
-
 	}
 	defer session.Close()
 

--- a/qan/analyzer/mongo/profiler/profiler.go
+++ b/qan/analyzer/mongo/profiler/profiler.go
@@ -141,17 +141,14 @@ func start(
 	// stop all monitors
 	defer monitors.StopAll()
 
-	firstTry := true
+	// monitor all databases
+	monitors.MonitorAll()
+
+	// signal we started monitoring
+	signalReady(ready)
+
+	// loop to periodically refresh monitors
 	for {
-		// update
-		monitors.MonitorAll()
-
-		if firstTry {
-			// signal we started monitoring
-			signalReady(ready)
-			firstTry = false
-		}
-
 		// check if we should shutdown
 		select {
 		case <-doneChan:
@@ -159,6 +156,9 @@ func start(
 		case <-time.After(1 * time.Minute):
 			// just continue after delay if not
 		}
+
+		// update monitors
+		monitors.MonitorAll()
 	}
 }
 

--- a/query/plugin/mongo/explain/explain.go
+++ b/query/plugin/mongo/explain/explain.go
@@ -37,9 +37,9 @@ func Explain(dsn, db, query string) (*proto.ExplainResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	dialInfo.Timeout = MgoTimeoutDialInfo
 	dialer := pmgo.NewDialer()
 
+	dialInfo.Timeout = MgoTimeoutDialInfo
 	session, err := dialer.DialWithInfo(dialInfo)
 	if err != nil {
 		return nil, err

--- a/query/plugin/mongo/explain/explain.go
+++ b/query/plugin/mongo/explain/explain.go
@@ -23,6 +23,7 @@ import (
 	"github.com/percona/percona-toolkit/src/go/mongolib/explain"
 	"github.com/percona/pmgo"
 	"github.com/percona/pmm/proto"
+	"gopkg.in/mgo.v2"
 )
 
 const (
@@ -45,6 +46,7 @@ func Explain(dsn, db, query string) (*proto.ExplainResult, error) {
 		return nil, err
 	}
 	defer session.Close()
+	session.SetMode(mgo.Eventual, true)
 	session.SetSyncTimeout(MgoTimeoutSessionSync)
 	session.SetSocketTimeout(MgoTimeoutSessionSocket)
 


### PR DESCRIPTION
# Run MongoDb with uninitiated replication:
  ```
  /home/nailya.kutlubaeva/download/percona-server-mongodb-3.4.6-1.7/bin/mongod --replSet r1 --dbpath=/home/nailya.kutlubaeva/download/percona-server-mongodb-3.4.6-1.7/data/rpldb1_1 --logpath=/home/nailya.kutlubaeva/download/percona-server-mongodb-3.4.6-1.7/data/rpldb1_1/mongod.log --port=16016 --logappend --fork
  ```
# Add this instance to monitoring:
  ```
  nailya.kutlubaeva@bm-dell02-qanqa01:~/download$  sudo pmm-admin add mongodb --cluster mongodb_cluster --uri localhost:16016 mongodb_inst_50_1  
  [linux:metrics]   OK, already monitoring this system.
  [mongodb:metrics] OK, now monitoring MongoDB metrics using URI localhost:16016
  [mongodb:queries] Error adding MongoDB queries: Put https://qwe123:qwe123@10.10.11.50/qan-api/agents/e9129d6873a94faf690db3f0499c7da2/cmd: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```