### PR TITLE
PMM-1549: fix parsing Source/auth db

### DIFF
--- a/qan/analyzer/mongo/profiler/monitors.go
+++ b/qan/analyzer/mongo/profiler/monitors.go
@@ -66,6 +66,24 @@ func (self *monitors) MonitorAll() error {
 		dialInfo := &pmgo.DialInfo{}
 		*dialInfo = *self.dialInfo
 
+		// When using `mongodb://admin:admin@localhost:27017/admin_db` and with databases [abc,test,xyz],
+		// we should authenticate to each [abc,test,xyz] database through `admin_db`.
+		// Instead we authenticated through database we were accessing e.g. for `abc` we authenticated through `abc`.
+		//
+		// The reason is that `ParseURL` doesn't set dialInfo.Source to default value when Source was not provided.
+		// Default authentication database is determined when calling `DialWithInfo` but still Source is left empty.
+		// https://github.com/go-mgo/mgo/issues/495
+		//
+		// If Source is empty it defaults to the value of Database, if that is set, or "admin" otherwise.
+		sourcedb := dialInfo.Source
+		if sourcedb == "" {
+			sourcedb = dialInfo.Database
+			if sourcedb == "" {
+				sourcedb = "admin"
+			}
+		}
+		dialInfo.Source = sourcedb
+
 		// set database name for connection
 		dialInfo.Database = dbName
 


### PR DESCRIPTION
# Issue
Consider 3 databases [a,b,c]. Below command will authenticate all 3 databases to `admin_db` database.
```
pmm-admin add mongodb --uri mongodb://admin:admin@localhost:27017/?authSource=admin_db
```
Both below commands will authenticate to:
 * a through a
 * b through b
 * c through c
```
pmm-admin add mongodb --uri mongodb://admin:admin@localhost:27017
pmm-admin add mongodb --uri mongodb://admin:admin@localhost:27017/admin_db
```

I think this is not correct behavior and not user friendly.

# Proposal

Below command will authenticate all 3 databases to default `admin` database.
```
pmm-admin add mongodb --uri mongodb://admin:admin@localhost:27017
```

Below commands will authenticate all 3 databases to admin_db database.
```
pmm-admin add mongodb --uri mongodb://admin:admin@localhost:27017/admin_db
pmm-admin add mongodb --uri mongodb://admin:admin@localhost:27017/?authSource=admin_db
```

I think this is more in sync with MongoDB documentation.
https://github.com/mongodb/docs/blob/99b70277c13d45f6d4177ec8c37a1df6714f6522/source/reference/connection-string.txt#L84-L92
> 
> /database 	Optional. The name of the database to authenticate if the connection string includes authentication credentials in the form of username:password@. If /database is not specified and the connection string includes credentials, the driver will authenticate to the admin database.
> 

https://docs.mongodb.com/manual/reference/connection-string/#urioption.authSource

> Specify the database name associated with the user’s credentials. authSource defaults to the database specified in the connection string.
> 
> For authentication mechanisms that delegate credential storage to other services, the authSource value should be $external as with the PLAIN (LDAP) and GSSAPI (Kerberos) authentication mechanisms.
>
> MongoDB will ignore authSource values if the connection string specifies no username.

I think it should be also more user friendly as simple:
```
pmm-admin add mongodb --uri mongodb://admin:admin@localhost:27017
```
... should setup monitoring for MongoDB server that is using default `admin` database for auth.
