### PR TITLE
PMM-873 Added agent/bin dir to the path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ env:
 
 matrix:
   include:
-    - go: 1.7.x
-      env:
     - go: 1.9.x
       env:
     - go: master

--- a/pct/cmd/cmd.go
+++ b/pct/cmd/cmd.go
@@ -82,7 +82,7 @@ func (c *RealCmd) Run() (output string, err error) {
 	if binfile, err := os.Executable(); err != nil {
 		basepath = path.Dir(binfile)
 		osPath := os.Getenv("PATH")
-		_ = os.Setenv("PATH", basepath+"/bin/"+string(filepath.ListSeparator)+osPath)
+		os.Setenv("PATH", basepath+"/bin/"+string(filepath.ListSeparator)+osPath)
 	}
 	cmd := exec.Command(c.name, c.args...)
 

--- a/pct/cmd/cmd.go
+++ b/pct/cmd/cmd.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path"
+	"path/filepath"
 	"time"
 )
 
@@ -76,6 +78,12 @@ func NewRealCmd(name string, args ...string) *RealCmd {
 }
 
 func (c *RealCmd) Run() (output string, err error) {
+	var basepath string
+	if binfile, err := os.Executable(); err != nil {
+		basepath = path.Dir(binfile)
+		osPath := os.Getenv("PATH")
+		_ = os.Setenv("PATH", basepath+"/bin/"+string(filepath.ListSeparator)+osPath)
+	}
 	cmd := exec.Command(c.name, c.args...)
 
 	// Workaround for "HOME: parameter not set"
@@ -84,6 +92,10 @@ func (c *RealCmd) Run() (output string, err error) {
 	}
 
 	resultChan := runCmd(cmd)
+	// Restore the path if it was changed
+	if basepath != "" {
+		os.Setenv("PATH", basepath)
+	}
 	select {
 	case <-time.After(c.Timeout):
 		killErr := cmd.Process.Kill()


### PR DESCRIPTION
Since we are going to distribute some extra tools like pt-summary along
with the pmm-client, this commit adds the agent's bin dir to the
beginning of the PATH env variable so we can call the extra tools
without specifying a PATH.
This is a local change that only affects the agent (not a system wide
change) and the original value is restored after running the external
command.

This code is setting the PATH env var instead of appending the path + binary, to make it pkg version independent. Since it will look for the binary in the PATH, it will work with current packages that don't have the pt-tools dependency and when we include the binaries it will also work.
