### PR TITLE
PMM-872 System summary - pt-summary API side

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -731,17 +731,13 @@ func (agent *Agent) handleCollectInfo() (interface{}, []error) {
 	zipFilename := path.Join(tmpDir, time.Now().Format("collect_2006-01-02_15_03_04.zip"))
 	zipFiles(zipFilename, outFiles)
 
+	// We cannot send binary data as a json payload. Let's base64 encode the zip.
 	b64data, err := base64Encode(zipFilename)
 	if err != nil {
 		return nil, []error{errors.Wrap(err, "cannot base64 encode the zip file")}
 	}
-	tmpfile, err := ioutil.TempFile("", "encode_")
-	ioutil.WriteFile(tmpfile.Name(), b64data, os.ModePerm)
-	tmpfile.Close()
-	fmt.Printf("temp encoded data file: %s\n", tmpfile.Name())
 
-	fmt.Printf("zip file name: %s\n", zipFilename)
-	//	removeFiles(append(outFiles, zipFilename))
+	removeFiles(append(outFiles, zipFilename))
 
 	return CollectInfoData{
 		Filename: zipFilename,

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -728,11 +728,14 @@ func (agent *Agent) handleCollectInfo() (interface{}, []error) {
 		}
 	}
 
-	zipFilename := path.Join(tmpDir, time.Now().Format("collect_2006-01-02_15_03_04.zip"))
-	zipFiles(zipFilename, outFiles)
+	// This is the name we send to the API
+	zipFilename := time.Now().Format("collect_2006-01-02_15_03_04.zip")
+	// This is the local temporary file name including the temp dir path
+	zipFilePath := path.Join(tmpDir, zipFilename)
+	zipFiles(zipFilePath, outFiles)
 
 	// We cannot send binary data as a json payload. Let's base64 encode the zip.
-	b64data, err := base64Encode(zipFilename)
+	b64data, err := base64Encode(zipFilePath)
 	if err != nil {
 		return nil, []error{errors.Wrap(err, "cannot base64 encode the zip file")}
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -18,12 +18,16 @@
 package agent
 
 import (
+	"archive/zip"
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -34,6 +38,7 @@ import (
 	"github.com/percona/qan-agent/agent/release"
 	"github.com/percona/qan-agent/pct"
 	pctCmd "github.com/percona/qan-agent/pct/cmd"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -70,6 +75,11 @@ type Agent struct {
 	status            *pct.Status
 	statusChan        chan *proto.Cmd
 	statusHandlerSync *pct.SyncChan
+}
+
+type CollectInfoData struct {
+	Filename string
+	Data     []byte
 }
 
 func NewAgent(config *pc.Agent, logger *pct.Logger, client pct.WebsocketClient, addr string, services map[string]pct.ServiceManager) *Agent {
@@ -500,6 +510,8 @@ func (agent *Agent) Handle(cmd *proto.Cmd) *proto.Reply {
 	// TODO @obsolete by query/plugin/mongo/summary
 	case "GetMongoSummary":
 		data, errs = agent.handleGetMongoSummary()
+	case "CollectServicesData":
+		data, errs = agent.handleCollectInfo()
 	default:
 		errs = append(errs, pct.UnknownCmdError{Cmd: cmd.Cmd})
 	}
@@ -696,6 +708,110 @@ func (agent *Agent) handleGetMySQLSummary() (interface{}, []error) {
 
 func (agent *Agent) handleGetMongoSummary() (interface{}, []error) {
 	return runRealCmd("pt-mongodb-summary")
+}
+
+func (agent *Agent) handleCollectInfo() (interface{}, []error) {
+	tmpDir, err := ioutil.TempDir("", "data_collection")
+	if err != nil {
+		return nil, []error{errors.Wrap(err, "cannot create temp dir for data collection")}
+	}
+
+	outFiles := []string{}
+	cmds := []string{"pt-summary", "pt-mysql-summary"}
+
+	for _, cmd := range cmds {
+		outFile := path.Join(tmpDir, cmd+".out")
+		outFiles = append(outFiles, outFile)
+		_, err := runRealCmd(cmd, "> "+outFile)
+		if err != nil && len(err) > 0 {
+			return nil, err
+		}
+	}
+
+	zipFilename := path.Join(tmpDir, time.Now().Format("collect_2006-01-02_15_03_04.zip"))
+	zipFiles(zipFilename, outFiles)
+
+	b64data, err := base64Encode(zipFilename)
+	if err != nil {
+		return nil, []error{errors.Wrap(err, "cannot base64 encode the zip file")}
+	}
+	tmpfile, err := ioutil.TempFile("", "encode_")
+	ioutil.WriteFile(tmpfile.Name(), b64data, os.ModePerm)
+	tmpfile.Close()
+	fmt.Printf("temp encoded data file: %s\n", tmpfile.Name())
+
+	fmt.Printf("zip file name: %s\n", zipFilename)
+	//	removeFiles(append(outFiles, zipFilename))
+
+	return CollectInfoData{
+		Filename: zipFilename,
+		Data:     b64data,
+	}, nil
+}
+
+func removeFiles(filenames []string) error {
+	for _, filename := range filenames {
+		err := os.Remove(filename)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("cannot remove temporary file %s", filename))
+		}
+	}
+	return nil
+}
+
+func base64Encode(filename string) ([]byte, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot open zip file")
+	}
+	var dst bytes.Buffer
+	w := base64.NewEncoder(base64.StdEncoding, &dst)
+	w.Write(data)
+	w.Close()
+
+	return dst.Bytes(), nil
+}
+
+func zipFiles(filename string, files []string) error {
+	newfile, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer newfile.Close()
+
+	zipWriter := zip.NewWriter(newfile)
+	defer zipWriter.Close()
+
+	for _, file := range files {
+
+		zipfile, err := os.Open(file)
+		if err != nil {
+			return err
+		}
+		defer zipfile.Close()
+
+		info, err := zipfile.Stat()
+		if err != nil {
+			return err
+		}
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+
+		header.Method = zip.Deflate
+
+		writer, err := zipWriter.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(writer, zipfile)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 //---------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,16 @@
 version: '3'
 services:
   mysql:
-    image: ${MYSQL_IMAGE:-percona/percona-server:5.7}
+    image: ${MYSQL_IMAGE:-mysql:5.7}
     ports:
       - ${MYSQL_HOST:-127.0.0.1}:${MYSQL_PORT:-3306}:3306
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
     # MariaDB >= 10.0.12 doesn't enable Performance Schema by default so we need to do it manually
     # https://mariadb.com/kb/en/mariadb/performance-schema-overview/#activating-the-performance-schema
-    command: --performance-schema
+    command: --performance-schema --secure-file-priv=""
+    volumes:
+      - ./test/schema/:/docker-entrypoint-initdb.d/:rw
   mongo:
     image: ${MONGODB_IMAGE:-percona/percona-server-mongodb:3.4}
     ports:

--- a/pct/cmd/cmd.go
+++ b/pct/cmd/cmd.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -84,14 +85,36 @@ func (c *RealCmd) Run() (output string, err error) {
 		osPath := os.Getenv("PATH")
 		os.Setenv("PATH", basepath+"/bin/"+string(filepath.ListSeparator)+osPath)
 	}
-	cmd := exec.Command(c.name, c.args...)
 
+	// Redirection using > is a shell/bash feature, not part of a command
+	// Here we try to detect output redirection and if there is a redirection,
+	// we need to create the output file and set cmd.Stout to that file
+	args := []string{}
+	outFilename := ""
+	var outfile *os.File
+
+	for _, arg := range c.args {
+		if strings.HasPrefix(arg, ">") {
+			outFilename = strings.TrimSpace(strings.TrimPrefix(arg, ">"))
+			break
+		}
+		args = append(args, arg)
+	}
+	cmd := exec.Command(c.name, args...)
+	if outFilename != "" {
+		outfile, err = os.Create(outFilename)
+		if err != nil {
+			return "", err
+		}
+		defer outfile.Close()
+		cmd.Stdout = outfile
+	}
 	// Workaround for "HOME: parameter not set"
 	if os.Getenv("HOME") == "" {
 		cmd.Env = append(os.Environ(), "HOME=/root")
 	}
 
-	resultChan := runCmd(cmd)
+	resultChan := runCmd(cmd, outFilename)
 	// Restore the path if it was changed
 	if basepath != "" {
 		os.Setenv("PATH", basepath)
@@ -119,12 +142,20 @@ func (c *RealCmd) Run() (output string, err error) {
 	}
 }
 
-func runCmd(cmd *exec.Cmd) (resultChan chan result) {
+func runCmd(cmd *exec.Cmd, redirectFile string) (resultChan chan result) {
 	// Below channels has buffer
 	// because we might get data before we would be waiting on this channel
 	resultChan = make(chan result, 1)
 	go func() {
-		output, err := cmd.CombinedOutput()
+		var output []byte
+		var err error
+
+		if redirectFile == "" {
+			output, err = cmd.CombinedOutput()
+		} else {
+			output = []byte(redirectFile)
+			err = cmd.Run()
+		}
 		select {
 		case resultChan <- result{output: string(output), err: err}:
 		default:

--- a/test/schema/pmm.sql
+++ b/test/schema/pmm.sql
@@ -1,0 +1,402 @@
+DROP DATABASE IF EXISTS dev_pmm;
+CREATE DATABASE dev_pmm;
+USE dev_pmm;
+
+SET time_zone='+00:00'; -- be sure we use right timezone otherwise dates like '1970-01-01 00:00:01' might become incorrect
+
+CREATE TABLE IF NOT EXISTS instances (
+  instance_id   INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  subsystem_id  INT UNSIGNED NOT NULL, -- 1=os, 2=agent, 3=mysql
+  parent_uuid   CHAR(32) NULL,
+  uuid          CHAR(32) NOT NULL,
+  name          VARCHAR(100) CHARSET 'utf8' NOT NULL,
+  dsn           VARCHAR(500) CHARSET 'utf8' NULL,  -- for addressable subsystems, like MySQL
+  distro        VARCHAR(100) CHARSET 'utf8' NULL,
+  version       VARCHAR(50)  CHARSET 'utf8' NULL,
+  created       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  deleted       TIMESTAMP NULL DEFAULT NULL,
+  PRIMARY KEY (instance_id),
+  UNIQUE INDEX (uuid),
+  UNIQUE INDEX (name, subsystem_id, deleted)
+);
+
+CREATE TABLE IF NOT EXISTS agent_configs (
+  agent_instance_id  INT UNSIGNED NOT NULL,
+  service            VARCHAR(10) NOT NULL,            -- agent, log, data, it, qan, mm, sysconfig
+  other_instance_id  INT UNSIGNED NOT NULL DEFAULT 0, -- if service uses another instance (qan, mm)
+  in_file            TEXT NOT NULL,                   -- JSON, aka "set" but this is reserved word
+  running            TEXT NOT NULL,                   -- JSON
+  updated            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (agent_instance_id, service, other_instance_id)
+);
+
+CREATE TABLE IF NOT EXISTS agent_log (
+  instance_id    INT UNSIGNED NOT NULL,
+  sec            BIGINT UNSIGNED NOT NULL,     -- Unix timestamp (seconds)
+  nsec           BIGINT UNSIGNED NOT NULL,     -- nanoseconds for ^
+  level          TINYINT(1) UNSIGNED NOT NULL, -- 7 debug, 6 info, ...
+  service        VARCHAR(50) NOT NULL,         -- service + instance name, e.g. mm-mysql-db01
+  msg            VARCHAR(5000) CHARSET 'utf8' NOT NULL,
+  INDEX (instance_id, sec, level)
+);
+
+CREATE TABLE IF NOT EXISTS query_classes (
+  query_class_id  INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  --
+  checksum           CHAR(32) NOT NULL,         -- F9CA3F38A5D4C05B
+  abstract           VARCHAR(100) DEFAULT NULL, -- SELECT t
+  fingerprint        VARCHAR(5000) NOT NULL,    -- select * from t where id=?
+  tables             TEXT DEFAULT NULL,
+  first_seen         TIMESTAMP NULL DEFAULT NULL,
+  last_seen          TIMESTAMP NULL DEFAULT NULL,
+  status             CHAR(3) NOT NULL DEFAULT 'new',
+  --
+  PRIMARY KEY (query_class_id),
+  UNIQUE INDEX (checksum)
+) CHARSET='utf8';
+
+CREATE TABLE IF NOT EXISTS query_examples (
+  query_class_id  INT UNSIGNED NOT NULL,           -- PK
+  instance_id     INT UNSIGNED NOT NULL DEFAULT 0, -- PK
+  period          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, -- PK
+  ts              TIMESTAMP NULL DEFAULT NULL,
+  db              VARCHAR(255) NOT NULL DEFAULT '',
+  Query_time      FLOAT NOT NULL DEFAULT 0,
+  query           TEXT NOT NULL,
+  --
+  PRIMARY KEY (query_class_id, instance_id, period)
+) CHARSET='utf8';
+
+CREATE TABLE IF NOT EXISTS query_global_metrics (
+  instance_id              INT UNSIGNED NOT NULL, -- PK
+  start_ts                 TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,    -- PK
+  end_ts                   TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
+  run_time                 FLOAT,
+  total_query_count        BIGINT UNSIGNED NOT NULL,
+  unique_query_count       BIGINT UNSIGNED NOT NULL,  -- number of query classes
+  -- Log file
+  rate_type                VARCHAR(10),            -- session or query (PS)
+  rate_limit               SMALLINT UNSIGNED,      -- every Nth rate_type (PS)
+  log_file                 VARCHAR(100),             -- slow_query_log_file
+  log_file_size            BIGINT UNSIGNED,
+  start_offset             BIGINT UNSIGNED,          -- in log_file
+  end_offset               BIGINT UNSIGNED,          -- in log_file
+  stop_offset              BIGINT UNSIGNED,          -- in log_file
+  -- Metrics
+  Query_time_sum       FLOAT,
+  Query_time_min       FLOAT,
+  Query_time_max       FLOAT,
+  Query_time_avg       FLOAT,
+  Query_time_p95       FLOAT,
+  Query_time_stddev    FLOAT,
+  Query_time_med       FLOAT,
+  Lock_time_sum        FLOAT,
+  Lock_time_min        FLOAT,
+  Lock_time_max        FLOAT,
+  Lock_time_avg        FLOAT,
+  Lock_time_p95        FLOAT,
+  Lock_time_stddev     FLOAT,
+  Lock_time_med        FLOAT,
+  Rows_sent_sum        BIGINT UNSIGNED,
+  Rows_sent_min        BIGINT UNSIGNED,
+  Rows_sent_max        BIGINT UNSIGNED,
+  Rows_sent_avg        BIGINT UNSIGNED,
+  Rows_sent_p95        BIGINT UNSIGNED,
+  Rows_sent_stddev     BIGINT UNSIGNED,
+  Rows_sent_med        BIGINT UNSIGNED,
+  Rows_examined_sum    BIGINT UNSIGNED,
+  Rows_examined_min    BIGINT UNSIGNED,
+  Rows_examined_max    BIGINT UNSIGNED,
+  Rows_examined_avg    BIGINT UNSIGNED,
+  Rows_examined_p95    BIGINT UNSIGNED,
+  Rows_examined_stddev BIGINT UNSIGNED,
+  Rows_examined_med    BIGINT UNSIGNED,
+  -- Percona extended slowlog attributes
+  -- http://www.percona.com/docs/wiki/patches:slow_extended
+  Rows_affected_sum             BIGINT UNSIGNED,
+  Rows_affected_min             BIGINT UNSIGNED,
+  Rows_affected_max             BIGINT UNSIGNED,
+  Rows_affected_avg             BIGINT UNSIGNED,
+  Rows_affected_p95             BIGINT UNSIGNED,
+  Rows_affected_stddev          BIGINT UNSIGNED,
+  Rows_affected_med             BIGINT UNSIGNED,
+  Rows_read_sum                 BIGINT UNSIGNED,
+  Rows_read_min                 BIGINT UNSIGNED,
+  Rows_read_max                 BIGINT UNSIGNED,
+  Rows_read_avg                 BIGINT UNSIGNED,
+  Rows_read_p95                 BIGINT UNSIGNED,
+  Rows_read_stddev              BIGINT UNSIGNED,
+  Rows_read_med                 BIGINT UNSIGNED,
+  Merge_passes_sum              BIGINT UNSIGNED,
+  Merge_passes_min              BIGINT UNSIGNED,
+  Merge_passes_max              BIGINT UNSIGNED,
+  Merge_passes_avg              BIGINT UNSIGNED,
+  Merge_passes_p95              BIGINT UNSIGNED,
+  Merge_passes_stddev           BIGINT UNSIGNED,
+  Merge_passes_med              BIGINT UNSIGNED,
+  InnoDB_IO_r_ops_sum           BIGINT UNSIGNED,
+  InnoDB_IO_r_ops_min           BIGINT UNSIGNED,
+  InnoDB_IO_r_ops_max           BIGINT UNSIGNED,
+  InnoDB_IO_r_ops_avg           BIGINT UNSIGNED,
+  InnoDB_IO_r_ops_p95           BIGINT UNSIGNED,
+  InnoDB_IO_r_ops_stddev        BIGINT UNSIGNED,
+  InnoDB_IO_r_ops_med           BIGINT UNSIGNED,
+  InnoDB_IO_r_bytes_sum         BIGINT UNSIGNED,
+  InnoDB_IO_r_bytes_min         BIGINT UNSIGNED,
+  InnoDB_IO_r_bytes_max         BIGINT UNSIGNED,
+  InnoDB_IO_r_bytes_avg         BIGINT UNSIGNED,
+  InnoDB_IO_r_bytes_p95         BIGINT UNSIGNED,
+  InnoDB_IO_r_bytes_stddev      BIGINT UNSIGNED,
+  InnoDB_IO_r_bytes_med         BIGINT UNSIGNED,
+  InnoDB_IO_r_wait_sum          FLOAT,
+  InnoDB_IO_r_wait_min          FLOAT,
+  InnoDB_IO_r_wait_max          FLOAT,
+  InnoDB_IO_r_wait_avg          FLOAT,
+  InnoDB_IO_r_wait_p95          FLOAT,
+  InnoDB_IO_r_wait_stddev       FLOAT,
+  InnoDB_IO_r_wait_med          FLOAT,
+  InnoDB_rec_lock_wait_sum      FLOAT,
+  InnoDB_rec_lock_wait_min      FLOAT,
+  InnoDB_rec_lock_wait_max      FLOAT,
+  InnoDB_rec_lock_wait_avg      FLOAT,
+  InnoDB_rec_lock_wait_p95      FLOAT,
+  InnoDB_rec_lock_wait_stddev   FLOAT,
+  InnoDB_rec_lock_wait_med      FLOAT,
+  InnoDB_queue_wait_sum         FLOAT,
+  InnoDB_queue_wait_min         FLOAT,
+  InnoDB_queue_wait_max         FLOAT,
+  InnoDB_queue_wait_avg         FLOAT,
+  InnoDB_queue_wait_p95         FLOAT,
+  InnoDB_queue_wait_stddev      FLOAT,
+  InnoDB_queue_wait_med         FLOAT,
+  InnoDB_pages_distinct_sum     BIGINT UNSIGNED,
+  InnoDB_pages_distinct_min     BIGINT UNSIGNED,
+  InnoDB_pages_distinct_max     BIGINT UNSIGNED,
+  InnoDB_pages_distinct_avg     BIGINT UNSIGNED,
+  InnoDB_pages_distinct_p95     BIGINT UNSIGNED,
+  InnoDB_pages_distinct_stddev  BIGINT UNSIGNED,
+  InnoDB_pages_distinct_med     BIGINT UNSIGNED,
+  -- Yes/No metrics
+  -- sum/global.total_query_count = % true
+  QC_Hit_sum                    BIGINT UNSIGNED,
+  Full_scan_sum                 BIGINT UNSIGNED,
+  Full_join_sum                 BIGINT UNSIGNED,
+  Tmp_table_sum                 BIGINT UNSIGNED,
+  Tmp_table_on_disk_sum         BIGINT UNSIGNED,
+  Filesort_sum                  BIGINT UNSIGNED,
+  Filesort_on_disk_sum          BIGINT UNSIGNED,
+  -- Meta metrics
+  Query_length_sum              BIGINT UNSIGNED,
+  Query_length_min              BIGINT UNSIGNED,
+  Query_length_max              BIGINT UNSIGNED,
+  Query_length_avg              BIGINT UNSIGNED,
+  Query_length_p95              BIGINT UNSIGNED,
+  Query_length_stddev           BIGINT UNSIGNED,
+  Query_length_med              BIGINT UNSIGNED,
+  -- Memory footprint metrics
+  Bytes_sent_sum                BIGINT UNSIGNED,
+  Bytes_sent_min                BIGINT UNSIGNED,
+  Bytes_sent_max                BIGINT UNSIGNED,
+  Bytes_sent_avg                BIGINT UNSIGNED,
+  Bytes_sent_p95                BIGINT UNSIGNED,
+  Bytes_sent_stddev             BIGINT UNSIGNED,
+  Bytes_sent_med                BIGINT UNSIGNED,
+  Tmp_tables_sum                BIGINT UNSIGNED,
+  Tmp_tables_min                BIGINT UNSIGNED,
+  Tmp_tables_max                BIGINT UNSIGNED,
+  Tmp_tables_avg                BIGINT UNSIGNED,
+  Tmp_tables_p95                BIGINT UNSIGNED,
+  Tmp_tables_stddev             BIGINT UNSIGNED,
+  Tmp_tables_med                BIGINT UNSIGNED,
+  Tmp_disk_tables_sum           BIGINT UNSIGNED,
+  Tmp_disk_tables_min           BIGINT UNSIGNED,
+  Tmp_disk_tables_max           BIGINT UNSIGNED,
+  Tmp_disk_tables_avg           BIGINT UNSIGNED,
+  Tmp_disk_tables_p95           BIGINT UNSIGNED,
+  Tmp_disk_tables_stddev        BIGINT UNSIGNED,
+  Tmp_disk_tables_med           BIGINT UNSIGNED,
+  Tmp_table_sizes_sum           BIGINT UNSIGNED,
+  Tmp_table_sizes_min           BIGINT UNSIGNED,
+  Tmp_table_sizes_max           BIGINT UNSIGNED,
+  Tmp_table_sizes_avg           BIGINT UNSIGNED,
+  Tmp_table_sizes_p95           BIGINT UNSIGNED,
+  Tmp_table_sizes_stddev        BIGINT UNSIGNED,
+  Tmp_table_sizes_med           BIGINT UNSIGNED,
+  -- Performance Schema
+  Errors_sum                    BIGINT UNSIGNED,
+  Warnings_sum                  BIGINT UNSIGNED,
+  Select_full_range_join_sum    BIGINT UNSIGNED,
+  Select_range_sum              BIGINT UNSIGNED,
+  Select_range_check_sum        BIGINT UNSIGNED,
+  Sort_range_sum                BIGINT UNSIGNED,
+  Sort_rows_sum                 BIGINT UNSIGNED,
+  Sort_scan_sum                 BIGINT UNSIGNED,
+  No_index_used_sum             BIGINT UNSIGNED,
+  No_good_index_used_sum        BIGINT UNSIGNED,
+  --
+  PRIMARY KEY (instance_id, start_ts),
+  INDEX (start_ts)
+);
+
+CREATE TABLE IF NOT EXISTS query_class_metrics (
+  query_class_id           INT UNSIGNED NOT NULL, -- PK
+  instance_id              INT UNSIGNED NOT NULL, -- PK
+  start_ts                 TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,    -- PK
+  end_ts                   TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
+  query_count              BIGINT UNSIGNED NOT NULL,
+  lrq_count                BIGINT UNSIGNED NOT NULL DEFAULT 0,  -- Low-ranking Queries
+  -- Metrics
+  Query_time_sum                FLOAT,
+  Query_time_min                FLOAT,
+  Query_time_max                FLOAT,
+  Query_time_avg                FLOAT,
+  Query_time_p95                FLOAT,
+  Query_time_stddev             FLOAT,
+  Query_time_med                FLOAT,
+  Lock_time_sum                 FLOAT,
+  Lock_time_min                 FLOAT,
+  Lock_time_max                 FLOAT,
+  Lock_time_avg                 FLOAT,
+  Lock_time_p95                 FLOAT,
+  Lock_time_stddev              FLOAT,
+  Lock_time_med                 FLOAT,
+  Rows_sent_sum                 BIGINT UNSIGNED,
+  Rows_sent_min                 BIGINT UNSIGNED,
+  Rows_sent_max                 BIGINT UNSIGNED,
+  Rows_sent_avg                 BIGINT UNSIGNED,
+  Rows_sent_p95                 BIGINT UNSIGNED,
+  Rows_sent_stddev              BIGINT UNSIGNED,
+  Rows_sent_med                 BIGINT UNSIGNED,
+  Rows_examined_sum             BIGINT UNSIGNED,
+  Rows_examined_min             BIGINT UNSIGNED,
+  Rows_examined_max             BIGINT UNSIGNED,
+  Rows_examined_avg             BIGINT UNSIGNED,
+  Rows_examined_p95             BIGINT UNSIGNED,
+  Rows_examined_stddev          BIGINT UNSIGNED,
+  Rows_examined_med             BIGINT UNSIGNED,
+  -- Percona extended slowlog attributes
+  -- http://www.percona.com/docs/wiki/patches:slow_extended
+  Rows_affected_sum             BIGINT UNSIGNED,
+  Rows_affected_min             BIGINT UNSIGNED,
+  Rows_affected_max             BIGINT UNSIGNED,
+  Rows_affected_avg             BIGINT UNSIGNED,
+  Rows_affected_p95             BIGINT UNSIGNED,
+  Rows_affected_stddev          BIGINT UNSIGNED,
+  Rows_affected_med             BIGINT UNSIGNED,
+  Rows_read_sum                 BIGINT UNSIGNED,
+  Rows_read_min                 BIGINT UNSIGNED,
+  Rows_read_max                 BIGINT UNSIGNED,
+  Rows_read_avg                 BIGINT UNSIGNED,
+  Rows_read_p95                 BIGINT UNSIGNED,
+  Rows_read_stddev              BIGINT UNSIGNED,
+  Rows_read_med                 BIGINT UNSIGNED,
+  Merge_passes_sum              BIGINT UNSIGNED,
+  Merge_passes_min              BIGINT UNSIGNED,
+  Merge_passes_max              BIGINT UNSIGNED,
+  Merge_passes_avg              BIGINT UNSIGNED,
+  Merge_passes_p95              BIGINT UNSIGNED,
+  Merge_passes_stddev           BIGINT UNSIGNED,
+  Merge_passes_med              BIGINT UNSIGNED,
+  InnoDB_IO_r_ops_sum           BIGINT UNSIGNED,
+  InnoDB_IO_r_ops_min           BIGINT UNSIGNED,
+  InnoDB_IO_r_ops_max           BIGINT UNSIGNED,
+  InnoDB_IO_r_ops_avg           BIGINT UNSIGNED,
+  InnoDB_IO_r_ops_p95           BIGINT UNSIGNED,
+  InnoDB_IO_r_ops_stddev        BIGINT UNSIGNED,
+  InnoDB_IO_r_ops_med           BIGINT UNSIGNED,
+  InnoDB_IO_r_bytes_sum         BIGINT UNSIGNED,
+  InnoDB_IO_r_bytes_min         BIGINT UNSIGNED,
+  InnoDB_IO_r_bytes_max         BIGINT UNSIGNED,
+  InnoDB_IO_r_bytes_avg         BIGINT UNSIGNED,
+  InnoDB_IO_r_bytes_p95         BIGINT UNSIGNED,
+  InnoDB_IO_r_bytes_stddev      BIGINT UNSIGNED,
+  InnoDB_IO_r_bytes_med         BIGINT UNSIGNED,
+  InnoDB_IO_r_wait_sum          FLOAT,
+  InnoDB_IO_r_wait_min          FLOAT,
+  InnoDB_IO_r_wait_max          FLOAT,
+  InnoDB_IO_r_wait_avg          FLOAT,
+  InnoDB_IO_r_wait_p95          FLOAT,
+  InnoDB_IO_r_wait_stddev       FLOAT,
+  InnoDB_IO_r_wait_med          FLOAT,
+  InnoDB_rec_lock_wait_sum      FLOAT,
+  InnoDB_rec_lock_wait_min      FLOAT,
+  InnoDB_rec_lock_wait_max      FLOAT,
+  InnoDB_rec_lock_wait_avg      FLOAT,
+  InnoDB_rec_lock_wait_p95      FLOAT,
+  InnoDB_rec_lock_wait_stddev   FLOAT,
+  InnoDB_rec_lock_wait_med      FLOAT,
+  InnoDB_queue_wait_sum         FLOAT,
+  InnoDB_queue_wait_min         FLOAT,
+  InnoDB_queue_wait_max         FLOAT,
+  InnoDB_queue_wait_avg         FLOAT,
+  InnoDB_queue_wait_p95         FLOAT,
+  InnoDB_queue_wait_stddev      FLOAT,
+  InnoDB_queue_wait_med         FLOAT,
+  InnoDB_pages_distinct_sum     BIGINT UNSIGNED,
+  InnoDB_pages_distinct_min     BIGINT UNSIGNED,
+  InnoDB_pages_distinct_max     BIGINT UNSIGNED,
+  InnoDB_pages_distinct_avg     BIGINT UNSIGNED,
+  InnoDB_pages_distinct_p95     BIGINT UNSIGNED,
+  InnoDB_pages_distinct_stddev  BIGINT UNSIGNED,
+  InnoDB_pages_distinct_med     BIGINT UNSIGNED,
+  -- Yes/No metrics
+  -- sum/class.query_count = % true
+  QC_Hit_sum                    BIGINT UNSIGNED,
+  Full_scan_sum                 BIGINT UNSIGNED,
+  Full_join_sum                 BIGINT UNSIGNED,
+  Tmp_table_sum                 BIGINT UNSIGNED,
+  Tmp_table_on_disk_sum         BIGINT UNSIGNED,
+  Filesort_sum                  BIGINT UNSIGNED,
+  Filesort_on_disk_sum          BIGINT UNSIGNED,
+  -- Meta metrics
+  Query_length_sum              BIGINT UNSIGNED,
+  Query_length_min              BIGINT UNSIGNED,
+  Query_length_max              BIGINT UNSIGNED,
+  Query_length_avg              BIGINT UNSIGNED,
+  Query_length_p95              BIGINT UNSIGNED,
+  Query_length_stddev           BIGINT UNSIGNED,
+  Query_length_med              BIGINT UNSIGNED,
+  -- Memory footprint metrics
+  Bytes_sent_sum                BIGINT UNSIGNED,
+  Bytes_sent_min                BIGINT UNSIGNED,
+  Bytes_sent_max                BIGINT UNSIGNED,
+  Bytes_sent_avg                BIGINT UNSIGNED,
+  Bytes_sent_p95                BIGINT UNSIGNED,
+  Bytes_sent_stddev             BIGINT UNSIGNED,
+  Bytes_sent_med                BIGINT UNSIGNED,
+  Tmp_tables_sum                BIGINT UNSIGNED,
+  Tmp_tables_min                BIGINT UNSIGNED,
+  Tmp_tables_max                BIGINT UNSIGNED,
+  Tmp_tables_avg                BIGINT UNSIGNED,
+  Tmp_tables_p95                BIGINT UNSIGNED,
+  Tmp_tables_stddev             BIGINT UNSIGNED,
+  Tmp_tables_med                BIGINT UNSIGNED,
+  Tmp_disk_tables_sum           BIGINT UNSIGNED,
+  Tmp_disk_tables_min           BIGINT UNSIGNED,
+  Tmp_disk_tables_max           BIGINT UNSIGNED,
+  Tmp_disk_tables_avg           BIGINT UNSIGNED,
+  Tmp_disk_tables_p95           BIGINT UNSIGNED,
+  Tmp_disk_tables_stddev        BIGINT UNSIGNED,
+  Tmp_disk_tables_med           BIGINT UNSIGNED,
+  Tmp_table_sizes_sum           BIGINT UNSIGNED,
+  Tmp_table_sizes_min           BIGINT UNSIGNED,
+  Tmp_table_sizes_max           BIGINT UNSIGNED,
+  Tmp_table_sizes_avg           BIGINT UNSIGNED,
+  Tmp_table_sizes_p95           BIGINT UNSIGNED,
+  Tmp_table_sizes_stddev        BIGINT UNSIGNED,
+  Tmp_table_sizes_med           BIGINT UNSIGNED,
+  -- Performance Schema
+  Errors_sum                    BIGINT UNSIGNED,
+  Warnings_sum                  BIGINT UNSIGNED,
+  Select_full_range_join_sum    BIGINT UNSIGNED,
+  Select_range_sum              BIGINT UNSIGNED,
+  Select_range_check_sum        BIGINT UNSIGNED,
+  Sort_range_sum                BIGINT UNSIGNED,
+  Sort_rows_sum                 BIGINT UNSIGNED,
+  Sort_scan_sum                 BIGINT UNSIGNED,
+  No_index_used_sum             BIGINT UNSIGNED,
+  No_good_index_used_sum        BIGINT UNSIGNED,
+  --
+  PRIMARY KEY (query_class_id, instance_id, start_ts),
+  INDEX (start_ts)
+);


### PR DESCRIPTION
Added CollectInfo service into the agent.
The new method runs `pt-summary` and `pt-mysql-summary` and outputs the results to text files.

That redirection is made 100% Go code, not relying on bash/shell re-direction to avoid possible issues. 

Also, by reading and zipping external files, we can easily add other commands that write the output to files, like `pt-stalk`
