### PR TITLE
PMM-1660: Disable automatic replicaSet detection + properly refresh session

### DIFF
--- a/qan/analyzer/mongo/profiler/monitors.go
+++ b/qan/analyzer/mongo/profiler/monitors.go
@@ -132,6 +132,8 @@ func (self *monitors) GetAll() map[string]*monitor {
 
 func listDatabases(dialInfo *pmgo.DialInfo, dialer pmgo.Dialer) ([]string, error) {
 	dialInfo.Timeout = MgoTimeoutDialInfo
+	// Disable automatic replicaSet detection, connect directly to specified server
+	dialInfo.Direct = true
 	session, err := dialer.DialWithInfo(dialInfo)
 	if err != nil {
 		return nil, err

--- a/query/plugin/mongo/explain/explain.go
+++ b/query/plugin/mongo/explain/explain.go
@@ -41,6 +41,8 @@ func Explain(dsn, db, query string) (*proto.ExplainResult, error) {
 	dialer := pmgo.NewDialer()
 
 	dialInfo.Timeout = MgoTimeoutDialInfo
+	// Disable automatic replicaSet detection, connect directly to specified server
+	dialInfo.Direct = true
 	session, err := dialer.DialWithInfo(dialInfo)
 	if err != nil {
 		return nil, err

--- a/test/profiling/profiling.go
+++ b/test/profiling/profiling.go
@@ -84,6 +84,8 @@ func createSession(url string) (pmgo.SessionManager, error) {
 	}
 	dialer := pmgo.NewDialer()
 
+	// Disable automatic replicaSet detection, connect directly to specified server
+	dialInfo.Direct = true
 	session, err := dialer.DialWithInfo(dialInfo)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* QAN exporter shouldn't connect to random node in replicaSet, but always to the same one.
In replicaSet without `direct=1` we were connecting to one of the replica members instead of always the same one. mongodb_exporter is doing this properly. Same fix should be also done for PT tools.
  From the user perspective this was resulting in non-working QAN at all. For example,
  * run 6 replicas (https://docs.mongodb.com/manual/tutorial/deploy-replica-set/)
  * turn on profiling on just 1 member
  * check in QAN UI if STATUS tab shows information that profiling is turned on (refresh several times, you might already notice that it sometimes shows yes, and sometimes no)
  * turn on monitoring with `pmm-admin add mongodb` on member
  * generate some queries and check if QAN UI works, you shouldn't have any or many queries should be missing. If problem doesn't occur, repeat process on another member as with 6 members you have 1/6 chance to connect to correct member.
     

  A workaround for the problem is using `direct=1` in DSN e.g. `pmm-admin add mongodb --uri localhost:27017/?direct=1` which for replicaSet is required since otherwise you end up with non working QAN, so it should be hard-coded.
* Properly refresh session after error occurs.