### PR TITLE
fix: MySQLAnalyzer.Stop should stop watching MySQL instance

### DIFF
--- a/qan/analyzer/mysql/mysql.go
+++ b/qan/analyzer/mysql/mysql.go
@@ -143,6 +143,7 @@ func (m *MySQLAnalyzer) Start() error {
 		m.clock,
 		m.spool,
 	)
+	m.restartChan = restartChan
 
 	return m.analyzer.Start()
 }


### PR DESCRIPTION
`MySQLAnalyzer.Stop` should stop watching MySQL instance, but `m.restartChan` is not initialized.

Checker is leak after start-then-stop analyzer.