### PR TITLE
PMM-1845 Updated FLUSH LOGS statement

### DIFF
--- a/qan/analyzer/mysql/worker/slowlog/slowlog_test.go
+++ b/qan/analyzer/mysql/worker/slowlog/slowlog_test.go
@@ -334,7 +334,7 @@ func (s *WorkerTestSuite) TestRotateAndRemoveSlowLog(t *C) {
 	w.Setup(i2)
 	gotSet = s.nullmysql.GetExec()
 	expectSet := append(config.Stop, config.Start...)
-	expectSet = append(expectSet, "FLUSH SLOW LOGS")
+	expectSet = append(expectSet, "FLUSH NO_WRITE_TO_BINLOG SLOW LOGS")
 	assert.Equal(t, expectSet, gotSet)
 
 	// When rotated, the interval end offset is extended to end of file.
@@ -432,7 +432,7 @@ func (s *WorkerTestSuite) TestRotateSlowLog(t *C) {
 	w.Setup(i2)
 	gotSet = s.nullmysql.GetExec()
 	expectSet := append(config.Stop, config.Start...)
-	expectSet = append(expectSet, "FLUSH SLOW LOGS")
+	expectSet = append(expectSet, "FLUSH NO_WRITE_TO_BINLOG SLOW LOGS")
 	assert.Equal(t, expectSet, gotSet)
 
 	// When rotated, the interval end offset is extended to end of file.
@@ -515,7 +515,7 @@ func (s *WorkerTestSuite) TestRotateRealSlowLog(t *C) {
 			Set: "SET GLOBAL slow_query_log=0",
 		},
 		{
-			Set: "FLUSH SLOW LOGS",
+			Set: "FLUSH NO_WRITE_TO_BINLOG SLOW LOGS",
 		},
 		{
 			Set:    fmt.Sprintf("SET GLOBAL slow_query_log_file='%s'", slowlogFile),
@@ -546,7 +546,7 @@ func (s *WorkerTestSuite) TestRotateRealSlowLog(t *C) {
 		},
 		Stop: []string{
 			"SET GLOBAL slow_query_log=0",
-			"FLUSH SLOW LOGS",
+			"FLUSH NO_WRITE_TO_BINLOG SLOW LOGS",
 		},
 		CollectFrom: "slowlog",
 	}

--- a/qan/analyzer/mysql/worker/slowlog/worker.go
+++ b/qan/analyzer/mysql/worker/slowlog/worker.go
@@ -416,7 +416,7 @@ func (w *Worker) rotateSlowLog(interval *iter.Interval) error {
 		return err
 	}
 
-	if err := w.mysqlConn.Exec([]string{"FLUSH SLOW LOGS"}); err != nil {
+	if err := w.mysqlConn.Exec([]string{"FLUSH NO_WRITE_TO_BINLOG SLOW LOGS"}); err != nil {
 		// MySQL 5.1 support.
 		if err := w.mysqlConn.Exec([]string{"FLUSH LOGS"}); err != nil {
 			return err


### PR DESCRIPTION
Since FLUSH SLOW LOGS is replicated, it generates a GTID event that
executes on the slave and thus contains a GTID event that preclude it
from being promoted as a master.

Changed `FLUSH LOGS` to `FLUSH NO_WRITE_TO_BINLOG SLOW LOGS`

```
#    End of Cover Report      #
###############################
ALL TESTS PASS
```