### PR TITLE
QAN fixes for MongoDB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
 addons:
   apt:
     sources:
-      - sourceline: "deb http://repo.percona.com/apt $(lsb_release -s -c) testing"
+      - sourceline: "deb http://repo.percona.com/apt $(lsb_release -s -c) main"
         key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x8507EFA5'
     packages:
       - percona-toolkit

--- a/bin/percona-qan-agent/main.go
+++ b/bin/percona-qan-agent/main.go
@@ -22,6 +22,8 @@ import (
 	"flag"
 	"fmt"
 	golog "log"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"os/user"
@@ -75,7 +77,7 @@ func init() {
 
 	flag.Parse()
 
-	// We don't accept any possitional arguments
+	// We don't accept any positional arguments
 	if len(flag.Args()) != 0 {
 		flag.Usage()
 		os.Exit(1)
@@ -303,6 +305,11 @@ func run(agentConfig *pc.Agent) error {
 			"query":    queryManager,
 		},
 	)
+
+	// Start http server for pprof
+	go func() {
+		golog.Println(http.ListenAndServe("localhost:6060", nil))
+	}()
 
 	// Run the agent, wait for it to stop, signal, or crash.
 	stopChan := make(chan error, 2)

--- a/bin/percona-qan-agent/main.go
+++ b/bin/percona-qan-agent/main.go
@@ -22,8 +22,6 @@ import (
 	"flag"
 	"fmt"
 	golog "log"
-	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"os/user"
@@ -305,11 +303,6 @@ func run(agentConfig *pc.Agent) error {
 			"query":    queryManager,
 		},
 	)
-
-	// Start http server for pprof
-	go func() {
-		golog.Println(http.ListenAndServe("localhost:6060", nil))
-	}()
 
 	// Run the agent, wait for it to stop, signal, or crash.
 	stopChan := make(chan error, 2)

--- a/qan/analyzer/factory/factory_test.go
+++ b/qan/analyzer/factory/factory_test.go
@@ -101,16 +101,12 @@ func TestFactory_MakeMongo(t *testing.T) {
 	}
 	for _, dbName := range dbNames {
 		t := map[string]string{
-			"%s-collector-profile":                  "Profiling disabled. Please enable profiling for this database or whole MongoDB server (https://docs.mongodb.com/manual/tutorial/manage-the-database-profiler/).",
-			"%s-collector-iterator-counter":         "1",
-			"%s-collector-iterator-restart-counter": shouldExist,
-			"%s-collector-iterator-created":         shouldExist,
-			"%s-collector-started":                  shouldExist,
-			"%s-collector-servers":                  shouldExist,
-			"%s-parser-started":                     shouldExist,
-			"%s-parser-interval-start":              shouldExist,
-			"%s-parser-interval-end":                shouldExist,
-			"%s-sender-started":                     shouldExist,
+			"%s-collector-profile":          "Profiling disabled. Please enable profiling for this database or whole MongoDB server (https://docs.mongodb.com/manual/tutorial/manage-the-database-profiler/).",
+			"%s-collector-iterator-counter": "1",
+			"%s-collector-iterator-created": shouldExist,
+			"%s-collector-servers":          shouldExist,
+			"%s-parser-interval-start":      shouldExist,
+			"%s-parser-interval-end":        shouldExist,
 		}
 		m := map[string]string{}
 		for k, v := range t {

--- a/qan/analyzer/factory/factory_test.go
+++ b/qan/analyzer/factory/factory_test.go
@@ -94,6 +94,7 @@ func TestFactory_MakeMongo(t *testing.T) {
 	require.NoError(t, err)
 	// some values are unpredictable, e.g. time but they should exist
 	shouldExist := "<should exist>"
+	mayExist := "<may exist>"
 
 	pluginName := "plugin"
 	expect := map[string]string{
@@ -101,12 +102,13 @@ func TestFactory_MakeMongo(t *testing.T) {
 	}
 	for _, dbName := range dbNames {
 		t := map[string]string{
-			"%s-collector-profile":          "Profiling disabled. Please enable profiling for this database or whole MongoDB server (https://docs.mongodb.com/manual/tutorial/manage-the-database-profiler/).",
-			"%s-collector-iterator-counter": "1",
-			"%s-collector-iterator-created": shouldExist,
-			"%s-collector-servers":          shouldExist,
-			"%s-parser-interval-start":      shouldExist,
-			"%s-parser-interval-end":        shouldExist,
+			"%s-collector-profile":                  "Profiling disabled. Please enable profiling for this database or whole MongoDB server (https://docs.mongodb.com/manual/tutorial/manage-the-database-profiler/).",
+			"%s-collector-iterator-counter":         "1",
+			"%s-collector-iterator-restart-counter": mayExist,
+			"%s-collector-iterator-created":         shouldExist,
+			"%s-collector-servers":                  shouldExist,
+			"%s-parser-interval-start":              shouldExist,
+			"%s-parser-interval-end":                shouldExist,
 		}
 		m := map[string]string{}
 		for k, v := range t {
@@ -119,11 +121,15 @@ func TestFactory_MakeMongo(t *testing.T) {
 
 	actual := plugin.Status()
 	for k, v := range expect {
-		if v == shouldExist {
+		switch v {
+		case shouldExist:
 			assert.Contains(t, actual, k)
-			delete(actual, k)
-			delete(expect, k)
+		case mayExist:
+		default:
+			continue
 		}
+		delete(actual, k)
+		delete(expect, k)
 	}
 	assert.Equal(t, expect, actual)
 	err = plugin.Stop()

--- a/qan/analyzer/factory/factory_test.go
+++ b/qan/analyzer/factory/factory_test.go
@@ -101,14 +101,16 @@ func TestFactory_MakeMongo(t *testing.T) {
 	}
 	for _, dbName := range dbNames {
 		t := map[string]string{
-			"%s-collector-profile":          "Profiling disabled. Please enable profiling for this database or whole MongoDB server (https://docs.mongodb.com/manual/tutorial/manage-the-database-profiler/).",
-			"%s-collector-iterator-counter": "1",
-			"%s-collector-iterator-created": shouldExist,
-			"%s-collector-started":          shouldExist,
-			"%s-parser-started":             shouldExist,
-			"%s-parser-interval-start":      shouldExist,
-			"%s-parser-interval-end":        shouldExist,
-			"%s-sender-started":             shouldExist,
+			"%s-collector-profile":                  "Profiling disabled. Please enable profiling for this database or whole MongoDB server (https://docs.mongodb.com/manual/tutorial/manage-the-database-profiler/).",
+			"%s-collector-iterator-counter":         "1",
+			"%s-collector-iterator-restart-counter": shouldExist,
+			"%s-collector-iterator-created":         shouldExist,
+			"%s-collector-started":                  shouldExist,
+			"%s-collector-servers":                  shouldExist,
+			"%s-parser-started":                     shouldExist,
+			"%s-parser-interval-start":              shouldExist,
+			"%s-parser-interval-end":                shouldExist,
+			"%s-sender-started":                     shouldExist,
 		}
 		m := map[string]string{}
 		for k, v := range t {

--- a/qan/analyzer/mongo/manager_test.go
+++ b/qan/analyzer/mongo/manager_test.go
@@ -121,16 +121,12 @@ func TestRealStartTool(t *testing.T) {
 	}
 	for _, dbName := range dbNames {
 		t := map[string]string{
-			"%s-collector-profile":                  "Profiling enabled for all queries (ratelimit: 1)",
-			"%s-collector-iterator-counter":         "1",
-			"%s-collector-iterator-restart-counter": shouldExist,
-			"%s-collector-iterator-created":         shouldExist,
-			"%s-collector-started":                  shouldExist,
-			"%s-collector-servers":                  shouldExist,
-			"%s-parser-started":                     shouldExist,
-			"%s-parser-interval-start":              shouldExist,
-			"%s-parser-interval-end":                shouldExist,
-			"%s-sender-started":                     shouldExist,
+			"%s-collector-profile":          "Profiling enabled for all queries (ratelimit: 1)",
+			"%s-collector-iterator-counter": "1",
+			"%s-collector-iterator-created": shouldExist,
+			"%s-collector-servers":          shouldExist,
+			"%s-parser-interval-start":      shouldExist,
+			"%s-parser-interval-end":        shouldExist,
 		}
 		m := map[string]string{}
 		for k, v := range t {

--- a/qan/analyzer/mongo/manager_test.go
+++ b/qan/analyzer/mongo/manager_test.go
@@ -112,6 +112,7 @@ func TestRealStartTool(t *testing.T) {
 
 	// Now the manager and analyzer should be running.
 	shouldExist := "<should exist>"
+	mayExist := "<may exist>"
 	actual := m.Status()
 
 	pluginName := fmt.Sprintf("%s-analyzer-%s-%s", cmd.Service, protoInstance.Subsystem, protoInstance.UUID)
@@ -121,12 +122,13 @@ func TestRealStartTool(t *testing.T) {
 	}
 	for _, dbName := range dbNames {
 		t := map[string]string{
-			"%s-collector-profile":          "Profiling enabled for all queries (ratelimit: 1)",
-			"%s-collector-iterator-counter": "1",
-			"%s-collector-iterator-created": shouldExist,
-			"%s-collector-servers":          shouldExist,
-			"%s-parser-interval-start":      shouldExist,
-			"%s-parser-interval-end":        shouldExist,
+			"%s-collector-profile":                  "Profiling enabled for all queries (ratelimit: 1)",
+			"%s-collector-iterator-counter":         "1",
+			"%s-collector-iterator-restart-counter": mayExist,
+			"%s-collector-iterator-created":         shouldExist,
+			"%s-collector-servers":                  shouldExist,
+			"%s-parser-interval-start":              shouldExist,
+			"%s-parser-interval-end":                shouldExist,
 		}
 		m := map[string]string{}
 		for k, v := range t {
@@ -138,11 +140,15 @@ func TestRealStartTool(t *testing.T) {
 	}
 
 	for k, v := range expect {
-		if v == shouldExist {
+		switch v {
+		case shouldExist:
 			assert.Contains(t, actual, k)
-			delete(actual, k)
-			delete(expect, k)
+		case mayExist:
+		default:
+			continue
 		}
+		delete(actual, k)
+		delete(expect, k)
 	}
 	expectJSON, err := json.Marshal(expect)
 	require.NoError(t, err)

--- a/qan/analyzer/mongo/manager_test.go
+++ b/qan/analyzer/mongo/manager_test.go
@@ -121,14 +121,16 @@ func TestRealStartTool(t *testing.T) {
 	}
 	for _, dbName := range dbNames {
 		t := map[string]string{
-			"%s-collector-profile":          "Profiling enabled for all queries (ratelimit: 1)",
-			"%s-collector-iterator-counter": "1",
-			"%s-collector-iterator-created": shouldExist,
-			"%s-collector-started":          shouldExist,
-			"%s-parser-started":             shouldExist,
-			"%s-parser-interval-start":      shouldExist,
-			"%s-parser-interval-end":        shouldExist,
-			"%s-sender-started":             shouldExist,
+			"%s-collector-profile":                  "Profiling enabled for all queries (ratelimit: 1)",
+			"%s-collector-iterator-counter":         "1",
+			"%s-collector-iterator-restart-counter": shouldExist,
+			"%s-collector-iterator-created":         shouldExist,
+			"%s-collector-started":                  shouldExist,
+			"%s-collector-servers":                  shouldExist,
+			"%s-parser-started":                     shouldExist,
+			"%s-parser-interval-start":              shouldExist,
+			"%s-parser-interval-end":                shouldExist,
+			"%s-sender-started":                     shouldExist,
 		}
 		m := map[string]string{}
 		for k, v := range t {

--- a/qan/analyzer/mongo/mongo.go
+++ b/qan/analyzer/mongo/mongo.go
@@ -12,7 +12,7 @@ import (
 	"github.com/percona/qan-agent/pct"
 	"github.com/percona/qan-agent/qan/analyzer"
 	"github.com/percona/qan-agent/qan/analyzer/mongo/profiler"
-	"github.com/percona/qan-agent/qan/analyzer/mongo/profiler/parser"
+	"github.com/percona/qan-agent/qan/analyzer/mongo/profiler/aggregator"
 )
 
 func New(ctx context.Context, protoInstance proto.Instance) analyzer.Analyzer {
@@ -132,8 +132,8 @@ func (m *MongoAnalyzer) Stop() error {
 func (m *MongoAnalyzer) GetDefaults(uuid string) map[string]interface{} {
 	// verify config
 	if m.config.Interval == 0 {
-		m.config.Interval = parser.DefaultInterval
-		m.config.ExampleQueries = parser.DefaultExampleQueries
+		m.config.Interval = aggregator.DefaultInterval
+		m.config.ExampleQueries = aggregator.DefaultExampleQueries
 	}
 
 	return map[string]interface{}{

--- a/qan/analyzer/mongo/mongo.go
+++ b/qan/analyzer/mongo/mongo.go
@@ -86,7 +86,10 @@ func (m *MongoAnalyzer) Start() error {
 		m.spool,
 		m.config,
 	)
-	m.profiler.Start()
+
+	if err := m.profiler.Start(); err != nil {
+		return err
+	}
 
 	m.running = true
 	return nil

--- a/qan/analyzer/mongo/mongo_test.go
+++ b/qan/analyzer/mongo/mongo_test.go
@@ -72,16 +72,12 @@ func TestMongo_StartStopStatus(t *testing.T) {
 	}
 	for _, dbName := range dbNames {
 		t := map[string]string{
-			"%s-collector-profile":                  "Profiling disabled. Please enable profiling for this database or whole MongoDB server (https://docs.mongodb.com/manual/tutorial/manage-the-database-profiler/).",
-			"%s-collector-iterator-counter":         "1",
-			"%s-collector-iterator-restart-counter": shouldExist,
-			"%s-collector-iterator-created":         shouldExist,
-			"%s-collector-started":                  shouldExist,
-			"%s-collector-servers":                  shouldExist,
-			"%s-parser-started":                     shouldExist,
-			"%s-parser-interval-start":              shouldExist,
-			"%s-parser-interval-end":                shouldExist,
-			"%s-sender-started":                     shouldExist,
+			"%s-collector-profile":          "Profiling disabled. Please enable profiling for this database or whole MongoDB server (https://docs.mongodb.com/manual/tutorial/manage-the-database-profiler/).",
+			"%s-collector-iterator-counter": "1",
+			"%s-collector-iterator-created": shouldExist,
+			"%s-collector-servers":          shouldExist,
+			"%s-parser-interval-start":      shouldExist,
+			"%s-parser-interval-end":        shouldExist,
 		}
 		m := map[string]string{}
 		for k, v := range t {

--- a/qan/analyzer/mongo/mongo_test.go
+++ b/qan/analyzer/mongo/mongo_test.go
@@ -65,6 +65,7 @@ func TestMongo_StartStopStatus(t *testing.T) {
 	require.NoError(t, err)
 	// some values are unpredictable, e.g. time but they should exist
 	shouldExist := "<should exist>"
+	mayExist := "<may exist>"
 
 	pluginName := "plugin"
 	expect := map[string]string{
@@ -72,12 +73,13 @@ func TestMongo_StartStopStatus(t *testing.T) {
 	}
 	for _, dbName := range dbNames {
 		t := map[string]string{
-			"%s-collector-profile":          "Profiling disabled. Please enable profiling for this database or whole MongoDB server (https://docs.mongodb.com/manual/tutorial/manage-the-database-profiler/).",
-			"%s-collector-iterator-counter": "1",
-			"%s-collector-iterator-created": shouldExist,
-			"%s-collector-servers":          shouldExist,
-			"%s-parser-interval-start":      shouldExist,
-			"%s-parser-interval-end":        shouldExist,
+			"%s-collector-profile":                  "Profiling disabled. Please enable profiling for this database or whole MongoDB server (https://docs.mongodb.com/manual/tutorial/manage-the-database-profiler/).",
+			"%s-collector-iterator-counter":         "1",
+			"%s-collector-iterator-restart-counter": mayExist,
+			"%s-collector-iterator-created":         shouldExist,
+			"%s-collector-servers":                  shouldExist,
+			"%s-parser-interval-start":              shouldExist,
+			"%s-parser-interval-end":                shouldExist,
 		}
 		m := map[string]string{}
 		for k, v := range t {
@@ -90,11 +92,15 @@ func TestMongo_StartStopStatus(t *testing.T) {
 
 	actual := plugin.Status()
 	for k, v := range expect {
-		if v == shouldExist {
+		switch v {
+		case shouldExist:
 			assert.Contains(t, actual, k)
-			delete(actual, k)
-			delete(expect, k)
+		case mayExist:
+		default:
+			continue
 		}
+		delete(actual, k)
+		delete(expect, k)
 	}
 	assert.Equal(t, expect, actual)
 

--- a/qan/analyzer/mongo/mongo_test.go
+++ b/qan/analyzer/mongo/mongo_test.go
@@ -66,23 +66,28 @@ func TestMongo_StartStopStatus(t *testing.T) {
 	// some values are unpredictable, e.g. time but they should exist
 	shouldExist := "<should exist>"
 
+	pluginName := "plugin"
 	expect := map[string]string{
-		"plugin": "Running",
+		pluginName: "Running",
 	}
 	for _, dbName := range dbNames {
 		t := map[string]string{
-			"plugin-%s-collector-profile":          "Profiling disabled. Please enable profiling for this database or whole MongoDB server (https://docs.mongodb.com/manual/tutorial/manage-the-database-profiler/).",
-			"plugin-%s-collector-iterator-counter": "1",
-			"plugin-%s-collector-iterator-created": shouldExist,
-			"plugin-%s-collector-started":          shouldExist,
-			"plugin-%s-parser-started":             shouldExist,
-			"plugin-%s-parser-interval-start":      shouldExist,
-			"plugin-%s-parser-interval-end":        shouldExist,
-			"plugin-%s-sender-started":             shouldExist,
+			"%s-collector-profile":                  "Profiling disabled. Please enable profiling for this database or whole MongoDB server (https://docs.mongodb.com/manual/tutorial/manage-the-database-profiler/).",
+			"%s-collector-iterator-counter":         "1",
+			"%s-collector-iterator-restart-counter": shouldExist,
+			"%s-collector-iterator-created":         shouldExist,
+			"%s-collector-started":                  shouldExist,
+			"%s-collector-servers":                  shouldExist,
+			"%s-parser-started":                     shouldExist,
+			"%s-parser-interval-start":              shouldExist,
+			"%s-parser-interval-end":                shouldExist,
+			"%s-sender-started":                     shouldExist,
 		}
 		m := map[string]string{}
 		for k, v := range t {
-			m[fmt.Sprintf(k, dbName)] = v
+			prefix := fmt.Sprintf("%s-%s", pluginName, dbName)
+			key := fmt.Sprintf(k, prefix)
+			m[key] = v
 		}
 		expect = merge(expect, m)
 	}

--- a/qan/analyzer/mongo/profiler/aggregator/aggregator.go
+++ b/qan/analyzer/mongo/profiler/aggregator/aggregator.go
@@ -140,7 +140,7 @@ func (self *Aggregator) createResult() *report.Result {
 
 		metrics := event.NewMetrics()
 
-		metrics.TimeMetrics["Query_time"] = newEventTimeStats(queryInfo.QueryTime)
+		metrics.TimeMetrics["Query_time"] = newEventTimeStatsInMilliseconds(queryInfo.QueryTime)
 
 		// @todo we map below metrics to MySQL equivalents according to PMM-830
 		metrics.NumberMetrics["Bytes_sent"] = newEventNumberStats(queryInfo.ResponseLength)
@@ -174,13 +174,13 @@ func newEventNumberStats(s stats.Statistics) *event.NumberStats {
 	}
 }
 
-func newEventTimeStats(s stats.Statistics) *event.TimeStats {
+func newEventTimeStatsInMilliseconds(s stats.Statistics) *event.TimeStats {
 	return &event.TimeStats{
-		Sum: s.Total,
-		Min: s.Min,
-		Avg: s.Avg,
-		Med: s.Median,
-		P95: s.Pct95,
-		Max: s.Max,
+		Sum: s.Total / 1000,
+		Min: s.Min / 1000,
+		Avg: s.Avg / 1000,
+		Med: s.Median / 1000,
+		P95: s.Pct95 / 1000,
+		Max: s.Max / 1000,
 	}
 }

--- a/qan/analyzer/mongo/profiler/collector/stats.go
+++ b/qan/analyzer/mongo/profiler/collector/stats.go
@@ -5,12 +5,13 @@ import (
 )
 
 type stats struct {
-	Started            *expvar.String `name:"started"`
-	In                 *expvar.Int    `name:"in"`
-	Out                *expvar.Int    `name:"out"`
-	IteratorCreated    *expvar.String `name:"iterator-created"`
-	IteratorCounter    *expvar.Int    `name:"iterator-counter"`
-	IteratorErrLast    *expvar.String `name:"iterator-err-last"`
-	IteratorErrCounter *expvar.Int    `name:"iterator-err-counter"`
-	IteratorTimeout    *expvar.Int    `name:"iterator-timeout"`
+	Started                *expvar.String `name:"started"`
+	In                     *expvar.Int    `name:"in"`
+	Out                    *expvar.Int    `name:"out"`
+	IteratorCreated        *expvar.String `name:"iterator-created"`
+	IteratorCounter        *expvar.Int    `name:"iterator-counter"`
+	IteratorRestartCounter *expvar.Int    `name:"iterator-restart-counter"`
+	IteratorErrLast        *expvar.String `name:"iterator-err-last"`
+	IteratorErrCounter     *expvar.Int    `name:"iterator-err-counter"`
+	IteratorTimeout        *expvar.Int    `name:"iterator-timeout"`
 }

--- a/qan/analyzer/mongo/profiler/collector/stats.go
+++ b/qan/analyzer/mongo/profiler/collector/stats.go
@@ -5,7 +5,6 @@ import (
 )
 
 type stats struct {
-	Started                *expvar.String `name:"started"`
 	In                     *expvar.Int    `name:"in"`
 	Out                    *expvar.Int    `name:"out"`
 	IteratorCreated        *expvar.String `name:"iterator-created"`

--- a/qan/analyzer/mongo/profiler/monitor.go
+++ b/qan/analyzer/mongo/profiler/monitor.go
@@ -15,16 +15,16 @@ import (
 )
 
 func NewMonitor(
-	dialInfo *pmgo.DialInfo,
-	dialer pmgo.Dialer,
+	session pmgo.SessionManager,
+	dbName string,
 	aggregator *aggregator.Aggregator,
 	logger *pct.Logger,
 	spool data.Spooler,
 	config pc.QAN,
 ) *monitor {
 	return &monitor{
-		dialInfo:   dialInfo,
-		dialer:     dialer,
+		session:    session,
+		dbName:     dbName,
 		aggregator: aggregator,
 		logger:     logger,
 		spool:      spool,
@@ -34,8 +34,8 @@ func NewMonitor(
 
 type monitor struct {
 	// dependencies
-	dialInfo   *pmgo.DialInfo
-	dialer     pmgo.Dialer
+	session    pmgo.SessionManager
+	dbName     string
 	aggregator *aggregator.Aggregator
 	spool      data.Spooler
 	logger     *pct.Logger
@@ -45,8 +45,8 @@ type monitor struct {
 	services []services
 
 	// state
-	sync.Mutex      // Lock() to protect internal consistency of the service
-	running    bool // Is this service running?
+	sync.RWMutex      // Lock() to protect internal consistency of the service
+	running      bool // Is this service running?
 }
 
 func (self *monitor) Start() error {
@@ -69,7 +69,7 @@ func (self *monitor) Start() error {
 	}()
 
 	// create collector and start it
-	c := collector.New(self.dialInfo, self.dialer)
+	c := collector.New(self.session, self.dbName)
 	docsChan, err := c.Start()
 	if err != nil {
 		return err
@@ -114,15 +114,31 @@ func (self *monitor) Stop() {
 
 // Status returns list of statuses
 func (self *monitor) Status() map[string]string {
-	statuses := map[string]string{}
+	self.RLock()
+	defer self.RUnlock()
 
+	statuses := &sync.Map{}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(len(self.services))
 	for _, s := range self.services {
-		for k, v := range s.Status() {
-			statuses[fmt.Sprintf("%s-%s", s.Name(), k)] = v
-		}
+		go func(s services) {
+			defer wg.Done()
+			for k, v := range s.Status() {
+				key := fmt.Sprintf("%s-%s", s.Name(), k)
+				statuses.Store(key, v)
+			}
+		}(s)
 	}
+	wg.Wait()
 
-	return statuses
+	statusesMap := map[string]string{}
+	statuses.Range(func(key, value interface{}) bool {
+		statusesMap[key.(string)] = value.(string)
+		return true
+	})
+
+	return statusesMap
 }
 
 type services interface {

--- a/qan/analyzer/mongo/profiler/parser/parser.go
+++ b/qan/analyzer/mongo/profiler/parser/parser.go
@@ -129,7 +129,6 @@ func start(
 	// update stats
 	stats.IntervalStart.Set(aggregator.TimeStart().Format("2006-01-02 15:04:05"))
 	stats.IntervalEnd.Set(aggregator.TimeEnd().Format("2006-01-02 15:04:05"))
-	stats.Started.Set(time.Now().UTC().Format("2006-01-02 15:04:05"))
 	for {
 		// check if we should shutdown
 		select {

--- a/qan/analyzer/mongo/profiler/parser/parser.go
+++ b/qan/analyzer/mongo/profiler/parser/parser.go
@@ -49,7 +49,7 @@ func (self *Parser) Start() (<-chan *qan.Report, error) {
 
 	// create new channels over which we will communicate to...
 	// ... outside world by sending collected docs
-	self.reportChan = make(chan *qan.Report)
+	self.reportChan = make(chan *qan.Report, 100)
 	// ... inside goroutine to close it
 	self.doneChan = make(chan struct{})
 

--- a/qan/analyzer/mongo/profiler/parser/stats.go
+++ b/qan/analyzer/mongo/profiler/parser/stats.go
@@ -5,7 +5,6 @@ import (
 )
 
 type stats struct {
-	Started        *expvar.String `name:"started"`
 	InDocs         *expvar.Int    `name:"docs-in"`
 	OkDocs         *expvar.Int    `name:"docs-ok"`
 	OutReports     *expvar.Int    `name:"reports-out"`

--- a/qan/analyzer/mongo/profiler/profiler.go
+++ b/qan/analyzer/mongo/profiler/profiler.go
@@ -9,6 +9,7 @@ import (
 	pc "github.com/percona/pmm/proto/config"
 	"github.com/percona/qan-agent/data"
 	"github.com/percona/qan-agent/pct"
+	"github.com/percona/qan-agent/qan/analyzer/mongo/profiler/aggregator"
 )
 
 func New(
@@ -18,6 +19,9 @@ func New(
 	spool data.Spooler,
 	config pc.QAN,
 ) *profiler {
+	// create aggregator which collects documents and aggregates them into qan report
+	aggregator := aggregator.New(time.Now(), config)
+
 	f := func(
 		dialInfo *pmgo.DialInfo,
 		dialer pmgo.Dialer,
@@ -25,11 +29,13 @@ func New(
 		return NewMonitor(
 			dialInfo,
 			dialer,
+			aggregator,
 			logger,
 			spool,
 			config,
 		)
 	}
+
 	m := NewMonitors(
 		dialInfo,
 		dialer,

--- a/qan/analyzer/mongo/profiler/profiler.go
+++ b/qan/analyzer/mongo/profiler/profiler.go
@@ -19,35 +19,12 @@ func New(
 	spool data.Spooler,
 	config pc.QAN,
 ) *profiler {
-	// create aggregator which collects documents and aggregates them into qan report
-	aggregator := aggregator.New(time.Now(), config)
-
-	f := func(
-		dialInfo *pmgo.DialInfo,
-		dialer pmgo.Dialer,
-	) *monitor {
-		return NewMonitor(
-			dialInfo,
-			dialer,
-			aggregator,
-			logger,
-			spool,
-			config,
-		)
-	}
-
-	m := NewMonitors(
-		dialInfo,
-		dialer,
-		f,
-	)
 	return &profiler{
 		dialInfo: dialInfo,
 		dialer:   dialer,
 		logger:   logger,
 		spool:    spool,
 		config:   config,
-		monitors: m,
 	}
 }
 
@@ -61,6 +38,7 @@ type profiler struct {
 
 	// monitors
 	monitors *monitors
+	session  pmgo.SessionManager
 
 	// state
 	sync.RWMutex                 // Lock() to protect internal consistency of the service
@@ -76,6 +54,36 @@ func (self *profiler) Start() error {
 	if self.running {
 		return nil
 	}
+
+	// create new session
+	session, err := createSession(self.dialInfo, self.dialer)
+	if err != nil {
+		return err
+	}
+	self.session = session
+
+	// create aggregator which collects documents and aggregates them into qan report
+	aggregator := aggregator.New(time.Now(), self.config)
+
+	f := func(
+		session pmgo.SessionManager,
+		dbName string,
+	) *monitor {
+		return NewMonitor(
+			session,
+			dbName,
+			aggregator,
+			self.logger,
+			self.spool,
+			self.config,
+		)
+	}
+
+	// create monitors service which we use to periodically scan server for new/removed databases
+	self.monitors = NewMonitors(
+		session,
+		f,
+	)
 
 	// create new channel over which
 	// we will tell goroutine it should close
@@ -107,13 +115,31 @@ func (self *profiler) Start() error {
 
 // Status returns list of statuses
 func (self *profiler) Status() map[string]string {
-	statuses := map[string]string{}
-	for dbName, p := range self.monitors.GetAll() {
-		for k, v := range p.Status() {
-			statuses[fmt.Sprintf("%s-%s", dbName, k)] = v
-		}
+	self.RLock()
+	defer self.RUnlock()
+
+	statuses := &sync.Map{}
+	monitors := self.monitors.GetAll()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(len(monitors))
+	for dbName, m := range monitors {
+		go func(dbName string, m *monitor) {
+			defer wg.Done()
+			for k, v := range m.Status() {
+				key := fmt.Sprintf("%s-%s", dbName, k)
+				statuses.Store(key, v)
+			}
+		}(dbName, m)
 	}
-	return statuses
+	wg.Wait()
+
+	statusesMap := map[string]string{}
+	statuses.Range(func(key, value interface{}) bool {
+		statusesMap[key.(string)] = value.(string)
+		return true
+	})
+	return statusesMap
 }
 
 // Stop stops running analyzer, waits until it stops
@@ -129,6 +155,9 @@ func (self *profiler) Stop() error {
 
 	// wait for goroutine to exit
 	self.wg.Wait()
+
+	// close the session; do it after goroutine is closed
+	self.session.Close()
 
 	// set state to "not running"
 	self.running = false

--- a/qan/analyzer/mongo/profiler/sender/sender.go
+++ b/qan/analyzer/mongo/profiler/sender/sender.go
@@ -2,7 +2,6 @@ package sender
 
 import (
 	"sync"
-	"time"
 
 	"github.com/percona/pmm/proto/qan"
 	"github.com/percona/qan-agent/data"
@@ -113,7 +112,6 @@ func start(
 	// signal WaitGroup when goroutine finished
 	defer wg.Done()
 
-	stats.Started.Set(time.Now().UTC().Format("2006-01-02 15:04:05"))
 	for {
 
 		select {

--- a/qan/analyzer/mongo/profiler/sender/stats.go
+++ b/qan/analyzer/mongo/profiler/sender/stats.go
@@ -5,8 +5,7 @@ import (
 )
 
 type stats struct {
-	Started *expvar.String `name:"started"`
-	In      *expvar.Int    `name:"in"`
-	Out     *expvar.Int    `name:"out"`
-	ErrIter *expvar.Int    `name:"err-iter"`
+	In      *expvar.Int `name:"in"`
+	Out     *expvar.Int `name:"out"`
+	ErrIter *expvar.Int `name:"err-iter"`
 }

--- a/qan/analyzer/mongo/profiler/session.go
+++ b/qan/analyzer/mongo/profiler/session.go
@@ -1,0 +1,21 @@
+package profiler
+
+import (
+	"github.com/percona/pmgo"
+	"gopkg.in/mgo.v2"
+)
+
+func createSession(dialInfo *pmgo.DialInfo, dialer pmgo.Dialer) (pmgo.SessionManager, error) {
+	dialInfo.Timeout = MgoTimeoutDialInfo
+	// Disable automatic replicaSet detection, connect directly to specified server
+	dialInfo.Direct = true
+	session, err := dialer.DialWithInfo(dialInfo)
+	if err != nil {
+		return nil, err
+	}
+	session.SetMode(mgo.Eventual, true)
+	session.SetSyncTimeout(MgoTimeoutSessionSync)
+	session.SetSocketTimeout(MgoTimeoutSessionSocket)
+
+	return session, nil
+}

--- a/test/mock/api.go
+++ b/test/mock/api.go
@@ -146,7 +146,7 @@ func (a *API) Hostname() string {
 	return a.hostname
 }
 
-func (a *API) Init(hostname string, headers map[string]string) (code int, err error) {
+func (a *API) Init(hostname string) (code int, err error) {
 	return http.StatusOK, nil
 }
 


### PR DESCRIPTION
While the idea of this PR was to fix [PMM-1660](https://jira.percona.com/browse/PMM-1660), during my investigation I couldn't reproduce the issue. For me monitoring replica set works, however I noticed several issues that could impact overall reception to the point that it looked like "it doesn't work", after we release this I will talk with the reporter again to try reproduce the issue.
![percona_query_analytics_and_percona_query_analytics_and_percona_query_analytics](https://user-images.githubusercontent.com/450355/34328145-f48764d0-e8d6-11e7-8a9c-ec8384f26558.png)
* [PMM-1631](https://jira.percona.com/browse/PMM-1631): Use one aggregator, API can't handle multiple samples, this could result in incorrect summary values.
* [PMM-1760](https://jira.percona.com/browse/PMM-1760): ignore collecting *.system.profile to avoid recursive create and collect cycle, which was resulting in high cpu usage and high load on mongod server (as our tool was generating thousands of samples). This was however happening only when we were collecting all samples, not only slow ones.
* [PMM-1760](https://jira.percona.com/browse/PMM-1760): use only one session and .Copy() it whenever needed to improve performance and safety.
* [PMM-1898](https://jira.percona.com/browse/PMM-1898): percona-toolkit Fingerprinter returns time in ms, but we use seconds in PMM
* collect all statuses in parallel
* properly restart invalid iterator (as suggested by mgo authro)
