### PR TITLE
PMM-2859: Update go-mysql.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -83,7 +83,6 @@
   revision = "179d4d0c4d8d407a32af483c2354df1d2c91e6c3"
 
 [[projects]]
-  branch = "master"
   name = "github.com/percona/go-mysql"
   packages = [
     "dsn",
@@ -92,7 +91,7 @@
     "log/slow",
     "query"
   ]
-  revision = "82ed67a1d0f1779cd60a025c54e0827da0c0838b"
+  revision = "8863d30f944bc83d6d7b1d5c4b3cfa2d69d84cf3"
 
 [[projects]]
   name = "github.com/percona/percona-toolkit"

--- a/qan/analyzer/mysql/worker/slowlog/slowlog_test.go
+++ b/qan/analyzer/mysql/worker/slowlog/slowlog_test.go
@@ -659,7 +659,7 @@ func (s *WorkerTestSuite) TestStop(t *C) {
 	// Send first event. This is aggregated.
 	e := &log.Event{
 		Offset: 0,
-		Ts:     "071015 21:45:10",
+		Ts:     time.Date(2017, 10, 15, 21, 45, 10, 0, time.UTC),
 		Query:  "select 1 from t",
 		Db:     "db1",
 		TimeMetrics: map[string]float64{
@@ -681,7 +681,7 @@ func (s *WorkerTestSuite) TestStop(t *C) {
 	// Send 2nd event which is not aggregated because a stop ^ is pending.
 	e = &log.Event{
 		Offset: 100,
-		Ts:     "071015 21:50:10",
+		Ts:     time.Date(2017, 10, 15, 21, 50, 10, 0, time.UTC),
 		Query:  "select 2 from u",
 		Db:     "db2",
 		TimeMetrics: map[string]float64{

--- a/test/qan/slow001-half.json
+++ b/test/qan/slow001-half.json
@@ -91,11 +91,12 @@
         "QueryTime": 2,
         "Db": "test",
         "Query": "select sleep(2) from n",
+        "Size": 22,
         "Ts": "2007-10-15 21:43:52"
       }
     }
   ],
   "RateLimit": 0,
   "RunTime": 0,
-  "StopOffset": 359
+  "StopOffset": 358
 }

--- a/test/qan/slow001-resume.json
+++ b/test/qan/slow001-resume.json
@@ -90,7 +90,8 @@
       "Example": {
         "QueryTime": 2,
         "Db": "sakila",
-        "Query": "select sleep(2) from test.n"
+        "Query": "select sleep(2) from test.n",
+        "Size": 27
       }
     }
   ],

--- a/test/qan/slow001.json
+++ b/test/qan/slow001.json
@@ -91,6 +91,7 @@
         "QueryTime": 2,
         "Db": "sakila",
         "Query": "select sleep(2) from test.n",
+        "Size": 27,
         "Ts": "2007-10-15 21:45:10"
       }
     },
@@ -141,6 +142,7 @@
         "QueryTime": 2,
         "Db": "test",
         "Query": "select sleep(2) from n",
+        "Size": 22,
         "Ts": "2007-10-15 21:43:52"
       }
     }

--- a/test/qan/slow001_another_tz.json
+++ b/test/qan/slow001_another_tz.json
@@ -91,6 +91,7 @@
         "QueryTime": 2,
         "Db": "sakila",
         "Query": "select sleep(2) from test.n",
+        "Size": 27,
         "Ts": "2007-10-15 22:45:10"
       }
     },
@@ -141,6 +142,7 @@
         "QueryTime": 2,
         "Db": "test",
         "Query": "select sleep(2) from n",
+        "Size": 22,
         "Ts": "2007-10-15 22:43:52"
       }
     }

--- a/test/qan/slow011.json
+++ b/test/qan/slow011.json
@@ -376,7 +376,9 @@
       "Example": {
         "QueryTime": 0.000237,
         "Db": "maindb",
-        "Query": "SELECT foo FROM bar WHERE id=2"
+        "Query": "SELECT foo FROM bar WHERE id=2",
+        "Size": 30,
+        "Ts": "2013-11-28 01:05:31"
       }
     },
     {
@@ -568,7 +570,8 @@
       "Example": {
         "QueryTime": 0.000165,
         "Db": "maindb",
-        "Query": "INSERT INTO foo VALUES (NULL, 3)"
+        "Query": "INSERT INTO foo VALUES (NULL, 3)",
+        "Size": 32
       }
     }
   ],

--- a/vendor/github.com/percona/go-mysql/dsn/dsn.go
+++ b/vendor/github.com/percona/go-mysql/dsn/dsn.go
@@ -18,15 +18,18 @@
 package dsn
 
 import (
+	"bytes"
+	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
+	"path"
 	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/shirou/gopsutil/net"
 	"github.com/shirou/gopsutil/process"
 )
 
@@ -53,10 +56,11 @@ const (
 )
 
 var (
-	ErrNoSocket error = errors.New("cannot auto-detect MySQL socket")
+	// ErrNoSocket is returned when GetSocketFromProcessLists can't locate socket.
+	ErrNoSocket = errors.New("cannot auto-detect MySQL socket")
 )
 
-func (dsn DSN) AutoDetect() (DSN, error) {
+func (dsn DSN) AutoDetect(ctx context.Context) (DSN, error) {
 	defaults, err := Defaults(dsn.DefaultsFile)
 	if err != nil {
 		return dsn, err
@@ -98,11 +102,11 @@ func (dsn DSN) AutoDetect() (DSN, error) {
 		if defaults.Socket != "" {
 			dsn.Socket = defaults.Socket
 		} else {
-			if socket, err := GetSocketFromProcessLists(); err != nil {
+			socket, err := GetSocket(ctx, dsn.String())
+			if err != nil {
 				return dsn, err
-			} else {
-				dsn.Socket = socket
 			}
+			dsn.Socket = socket
 		}
 	}
 
@@ -111,13 +115,13 @@ func (dsn DSN) AutoDetect() (DSN, error) {
 
 func Defaults(defaultsFile string) (DSN, error) {
 	versionParams := [][]string{
-		[]string{"-s", "client"},
-		[]string{"client"},
+		{"-s", "client"},
+		{"client"},
 	}
 	if defaultsFile != "" {
 		versionParams = [][]string{
-			[]string{"--defaults-file=" + defaultsFile, "-s", "client"},
-			[]string{"--defaults-file=" + defaultsFile, "client"},
+			{"--defaults-file=" + defaultsFile, "-s", "client"},
+			{"--defaults-file=" + defaultsFile, "client"},
 		}
 	}
 
@@ -200,36 +204,212 @@ func HidePassword(dsn string) string {
 	return dsn
 }
 
-// GetSocketFromProcessLists will loop through the list of PIDs until it finds a process
+// GetSocketFromTCPConnection will try to get socket path by connecting to MySQL localhost TCP port.
+// This is not reliable as TCP connections may be not allowed.
+func GetSocketFromTCPConnection(ctx context.Context, dsn string) (socket string, err error) {
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return "", ErrNoSocket
+	}
+	defer db.Close()
+
+	err = db.QueryRowContext(ctx, "SELECT @@socket").Scan(socket)
+	if err != nil {
+		return "", ErrNoSocket
+	}
+	if !path.IsAbs(socket) {
+		return "", ErrNoSocket
+	}
+	if socket != "" {
+		return socket, nil
+	}
+
+	return "", ErrNoSocket
+}
+
+// GetSocketFromProcessList will loop through the list of PIDs until it finds a process
 // named 'mysqld' and the it will try to get the socket by querying the open network
 // connections for that process.
 // Warning: this function returns the socket for the FIRST mysqld process it founds.
 // If there are more than one MySQL instance, only the first one will be detected.
-func GetSocketFromProcessLists() (string, error) {
+func GetSocketFromProcessList(ctx context.Context) (string, error) {
 	pids, err := process.Pids()
 	if err != nil {
 		return "", errors.Wrap(err, "Cannot get the list of PIDs")
 	}
+	socketsMap := map[string]struct{}{}
+	sockets := []string{}
+	mysqldPIDs := []string{}
 	for _, pid := range pids {
 		proc, err := process.NewProcess(pid)
 		if err != nil {
 			continue
 		}
-		if procName, err := proc.Name(); err != nil {
+		procName, err := proc.Name()
+		if err != nil {
 			continue
-		} else {
-			if procName == "mysqld" {
-				cons, err := net.ConnectionsPid("unix", pid)
-				if err != nil {
-					return "", errors.Wrapf(err, "Cannot get network connections for PID %d", pid)
-				}
-				if len(cons) > 0 {
-					return cons[0].Laddr.IP, nil
-				}
+		}
+		if procName != "mysqld" {
+			continue
+		}
+		mysqlPID := fmt.Sprintf("%d", pid)
+		mysqldPIDs = append(mysqldPIDs, mysqlPID)
+		socketsFromPID, err := GetSocketsFromPID(ctx, mysqlPID)
+		if err != nil {
+			return "", errors.Wrapf(err, "Cannot get network connections for PID %d", pid)
+		}
+		for _, socket := range socketsFromPID {
+			if strings.HasPrefix(socket, "->") {
+				continue
+			}
+			if strings.HasSuffix(socket, "/mysqlx.sock") {
+				continue
+			}
+			if _, exist := socketsMap[socket]; !exist {
+				socketsMap[socket] = struct{}{}
+				sockets = append(sockets, socket)
 			}
 		}
 	}
+	if len(sockets) > 1 {
+		log.Printf("lsof: multiple sockets detected for pid(s) %v, choosing first one: %s\n", mysqldPIDs, strings.Join(sockets, ", "))
+	}
+	if len(sockets) > 0 {
+		return sockets[0], nil
+	}
 	return "", ErrNoSocket
+}
+
+// GetSocketFromNetstat will loop through list of open sockets
+// and try to find one matching `mysql` word.
+// Warning: this function returns the socket for the FIRST entry it founds.
+// If there are more sockets containing `mysql` word, only the first one will be detected.
+func GetSocketFromNetstat(ctx context.Context) (string, error) {
+	// Try to auto-detect MySQL socket from netstat output.
+	out, err := exec.CommandContext(ctx, "netstat", "-anp").Output()
+	if err != nil {
+		return "", ErrNoSocket
+	}
+
+	socketsMap := map[string]struct{}{}
+	sockets := []string{}
+	lines := strings.Split(string(out), "\n")
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "unix") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		socket := fields[len(fields)-1]
+		if !path.IsAbs(socket) {
+			continue
+		}
+		if strings.HasSuffix(socket, "/mysqlx.sock") {
+			continue
+		}
+		if !strings.Contains(socket, "mysql") {
+			continue
+		}
+		if _, exist := socketsMap[socket]; !exist {
+			socketsMap[socket] = struct{}{}
+			sockets = append(sockets, socket)
+		}
+	}
+	if len(sockets) > 1 {
+		log.Println("netstat: multiple sockets detected, choosing first one:", strings.Join(sockets, ", "))
+	}
+	if len(sockets) > 0 {
+		return sockets[0], nil
+	}
+	return "", ErrNoSocket
+}
+
+// GetSocket tries to detect and return path to the MySQL socket.
+func GetSocket(ctx context.Context, dsn string) (string, error) {
+	var socket string
+	var err error
+	socket, err = GetSocketFromTCPConnection(ctx, dsn)
+	if err != nil {
+		socket, err = GetSocketFromProcessList(ctx)
+		if err != nil {
+			socket, err = GetSocketFromNetstat(ctx)
+		}
+	}
+	return socket, err
+}
+
+// GetSocketsFromPID returns currently open UNIX domain socket files by process identifier (PID).
+func GetSocketsFromPID(ctx context.Context, pid string) ([]string, error) {
+	cmd := exec.CommandContext(
+		ctx,
+		"lsof",
+		"-a",
+		"-n",
+		"-P",
+		"-U",
+		"-F",
+		"n",
+		"-p", pid,
+	)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseLsofForSockets(output), nil
+}
+
+// parseLsofForSockets parses `lsof -F n -p <pid>` output for open UNIX domain socket files.
+func parseLsofForSockets(output []byte) (sockets []string) {
+	socketsMap := map[string]struct{}{}
+	lines := bytes.Split(output, []byte("\n"))
+	for _, line := range lines {
+		// `lsof -F n`
+		// When the -F option is specified, lsof produces output that is suitable for processing by another program
+		// - e.g, an awk or Perl script, or a C program.
+		// n    file name, comment, Internet address
+		if !bytes.HasPrefix(line, []byte("n")) {
+			continue
+		}
+		line = bytes.TrimPrefix(line, []byte("n"))
+
+		// lsof on trusty:                 `/var/run/mysqld/mysqld.sock`
+		// lsof on xenial, artful, bionic: `/var/run/mysqld/mysqld.sock type=STREAM`
+		line = bytes.TrimSuffix(line, []byte("type=STREAM"))
+		line = bytes.TrimSpace(line)
+
+		// Skip empty lines.
+		if len(line) == 0 {
+			continue
+		}
+		socket := string(line)
+
+		// @Nailya had a case on xenial where `lsof` returned `ntype=DGRAM` and `ntype=STREAM` without any path.
+		// I'm not sure what are those but we can try to avoid this by checking for absolute path.
+		// # lsof -a -n -P -U -F n -p $(pgrep -x mysqld | tr \\n ,)
+		// p952
+		// f3
+		// ntype=DGRAM
+		// f18
+		// ntype=STREAM
+		// f19
+		// ntype=STREAM
+		// f22
+		// n/var/run/mysqld/mysqld.sock type=STREAM
+		// f24
+		// n/var/run/mysqld/mysqlx.sock type=STREAM
+		if !path.IsAbs(socket) {
+			continue
+		}
+
+		if _, exist := socketsMap[socket]; !exist {
+			socketsMap[socket] = struct{}{}
+			sockets = append(sockets, socket)
+		}
+	}
+
+	return sockets
 }
 
 func ParseMySQLDefaults(output string) DSN {

--- a/vendor/github.com/percona/go-mysql/event/aggregator.go
+++ b/vendor/github.com/percona/go-mysql/event/aggregator.go
@@ -89,7 +89,7 @@ func (a *Aggregator) Finalize() Result {
 		class.Finalize(a.rateLimit)
 		class.UniqueQueries = 1
 		if class.Example != nil && class.Example.Ts != "" {
-			if t, err := time.Parse("060102 15:04:05", class.Example.Ts); err != nil {
+			if t, err := time.Parse("2006-01-02 15:04:05", class.Example.Ts); err != nil {
 				class.Example.Ts = ""
 			} else {
 				class.Example.Ts = t.Add(a.utcOffset).Format("2006-01-02 15:04:05")

--- a/vendor/github.com/percona/go-mysql/event/class.go
+++ b/vendor/github.com/percona/go-mysql/event/class.go
@@ -22,7 +22,11 @@ import (
 )
 
 const (
-	MAX_EXAMPLE_BYTES = 1024 * 10
+	// MaxExampleBytes defines to how many bytes truncate a query.
+	MaxExampleBytes = 2 * 1024 * 10
+
+	// TruncatedExampleSuffix is added to truncated query.
+	TruncatedExampleSuffix = "..."
 )
 
 // A Class represents all events with the same fingerprint and class ID.
@@ -42,12 +46,13 @@ type Class struct {
 }
 
 // A Example is a real query and its database, timestamp, and Query_time.
-// If the query is larger than MAX_EXAMPLE_BYTES, it is truncated and "..."
+// If the query is larger than MaxExampleBytes, it is truncated and TruncatedExampleSuffix
 // is appended.
 type Example struct {
 	QueryTime float64 // Query_time
 	Db        string  // Schema: <db> or USE <db>
-	Query     string  // truncated to MAX_EXAMPLE_BYTES
+	Query     string  // truncated to MaxExampleBytes
+	Size      int     `json:",omitempty"` // Original size of query.
 	Ts        string  `json:",omitempty"` // in MySQL time zone
 }
 
@@ -84,17 +89,21 @@ func (c *Class) AddEvent(e *log.Event, outlier bool) {
 		if n, ok := e.TimeMetrics["Query_time"]; ok {
 			if float64(n) > c.Example.QueryTime {
 				c.Example.QueryTime = float64(n)
+				c.Example.Size = len(e.Query)
 				if e.Db != "" {
 					c.Example.Db = e.Db
 				} else {
 					c.Example.Db = c.lastDb
 				}
-				if len(e.Query) > MAX_EXAMPLE_BYTES {
-					c.Example.Query = e.Query[0:MAX_EXAMPLE_BYTES-3] + "..."
+				if len(e.Query) > MaxExampleBytes {
+					c.Example.Query = e.Query[0:MaxExampleBytes-len(TruncatedExampleSuffix)] + TruncatedExampleSuffix
 				} else {
 					c.Example.Query = e.Query
 				}
-				c.Example.Ts = e.Ts
+				// todo use time.RFC3339Nano instead
+				if !e.Ts.IsZero() {
+					c.Example.Ts = e.Ts.Format("2006-01-02 15:04:05")
+				}
 			}
 		}
 	}

--- a/vendor/github.com/percona/go-mysql/log/log.go
+++ b/vendor/github.com/percona/go-mysql/log/log.go
@@ -20,6 +20,10 @@
 // like max Query_time. See also percona.com/go-mysql/event/.
 package log
 
+import (
+	"time"
+)
+
 // An event is a query like "SELECT col FROM t WHERE id = 1", some metrics like
 // Query_time (slow log) or SUM_TIMER_WAIT (Performance Schema), and other
 // metadata like default database, timestamp, etc. Metrics and metadata are not
@@ -27,10 +31,11 @@ package log
 // event is expected to define the query and Query_time metric. Other metrics
 // and metadata vary according to MySQL version, distro, and configuration.
 type Event struct {
-	Offset        uint64 // byte offset in file at which event starts
-	Ts            string // raw timestamp of event
-	Admin         bool   // true if Query is admin command
-	Query         string // SQL query or admin command
+	Offset        uint64    // byte offset in file at which event starts
+	OffsetEnd     uint64    // byte offset in file at which event ends
+	Ts            time.Time // timestamp of event
+	Admin         bool      // true if Query is admin command
+	Query         string    // SQL query or admin command
 	User          string
 	Host          string
 	Db            string


### PR DESCRIPTION
* Update go-mysql library.
* Fixes parsing `# Time` for query examples in newer MySQL versions.
* Fixes parsing `# Time` which sometimes was not parsed at all because of the `Offset` shift by 1 byte.
* Fixes `Offset` so parsing from `StartOffset` correctly parses whole event.